### PR TITLE
fix(atomize): compare against target branch for change detection

### DIFF
--- a/.github/workflows/atomic-release-atomize-changes.yml
+++ b/.github/workflows/atomic-release-atomize-changes.yml
@@ -103,15 +103,12 @@ jobs:
         env:
           ARTIFACT_PATH: ${{ inputs.artifact_path }}
           MANIFEST_FILE: ${{ inputs.manifest_file }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
-          # Handle both squash merges and merge commits
-          if git rev-parse HEAD^2 >/dev/null 2>&1; then
-            RANGE="HEAD^..HEAD"
-            echo "::notice::Detected merge commit, using range: $RANGE"
-          else
-            RANGE="HEAD~1..HEAD"
-            echo "::notice::Detected squash/regular commit, using range: $RANGE"
-          fi
+          # Compare against target branch to detect ALL changes needing atomization
+          # This ensures we don't miss changes when multiple commits merge in sequence
+          RANGE="origin/${TARGET_BRANCH}..HEAD"
+          echo "::notice::Detecting changes using range: $RANGE"
 
           # Get all changed files
           CHANGED_FILES=$(git diff --name-only "$RANGE")


### PR DESCRIPTION
## Summary
- Fix change detection to compare against target branch instead of just last commit
- Prevents missing changes when multiple commits merge in sequence

## Problem
The atomize-changes workflow only checked `HEAD~1..HEAD` for changes. This failed when:
1. A chart/artifact change merges to integration
2. A CI-only change merges afterward
3. The workflow triggers on the CI commit
4. No artifacts are detected because only the last commit is checked

## Solution
Compare `origin/${TARGET_BRANCH}..HEAD` instead, which detects ALL changes between the target branch and current HEAD.

Fixes #18