### PR TITLE
fix(atomize): validate JSON before parsing attestation map

### DIFF
--- a/.github/workflows/atomic-release-atomize-changes.yml
+++ b/.github/workflows/atomic-release-atomize-changes.yml
@@ -184,6 +184,12 @@ jobs:
               attestation_map='{}'
             fi
 
+            # Validate JSON before using jq
+            if ! echo "$attestation_map" | jq empty 2>/dev/null; then
+              echo "::warning::Attestation map is not valid JSON, using empty map"
+              attestation_map='{}'
+            fi
+
             if [[ "$attestation_map" == "{}" ]]; then
               echo "::warning::Source PR #$pr_number has no attestation map"
             else


### PR DESCRIPTION
Add JSON validation before calling jq to prevent parse errors when the attestation map extraction returns invalid JSON.

Without this fix, the workflow fails with 'jq: parse error' when the source PR doesn't have a valid JSON attestation map.