### PR TITLE
feat(actions): add attestation category actions

### DIFF
--- a/actions/attestation/create/README.md
+++ b/actions/attestation/create/README.md
@@ -1,0 +1,99 @@
+# attestation/create
+
+Create attestation with optional PR map update.
+
+Wraps `actions/attest-build-provenance` with a consistent interface and
+automatically updates the PR attestation map if `pr-number` and `check-name`
+are provided.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `subject-name` | Yes | - | Name for the attestation subject |
+| `subject-digest` | Yes | - | SHA256 digest of the subject |
+| `pr-number` | No | - | PR number to update attestation map |
+| `check-name` | No | - | Check name for attestation map entry |
+| `push-to-registry` | No | `false` | Push attestation to GHCR |
+| `token` | No | `github.token` | GitHub token |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `attestation-id` | The generated attestation ID |
+| `bundle-path` | Path to the attestation bundle |
+
+## Usage
+
+### Basic Attestation
+
+```yaml
+- uses: arustydev/gha/actions/attestation/generate-digest@v1
+  id: digest
+  with:
+    content: '{"chart": "my-chart", "version": "1.2.3"}'
+    type: string
+
+- uses: arustydev/gha/actions/attestation/create@v1
+  id: attest
+  with:
+    subject-name: my-chart-v1.2.3
+    subject-digest: ${{ steps.digest.outputs.digest }}
+```
+
+### With PR Map Update
+
+```yaml
+- uses: arustydev/gha/actions/attestation/create@v1
+  id: attest
+  with:
+    subject-name: my-chart-v1.2.3
+    subject-digest: ${{ steps.digest.outputs.digest }}
+    pr-number: ${{ github.event.pull_request.number }}
+    check-name: lint-test
+```
+
+### Push to Registry
+
+```yaml
+- uses: arustydev/gha/actions/attestation/create@v1
+  id: attest
+  with:
+    subject-name: my-chart-v1.2.3
+    subject-digest: ${{ steps.digest.outputs.digest }}
+    push-to-registry: true
+```
+
+### Full Example (Lint Test)
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run lint
+        run: helm lint charts/my-chart
+
+      - uses: arustydev/gha/actions/attestation/generate-digest@v1
+        id: digest
+        with:
+          content: '{"check": "lint", "chart": "my-chart", "version": "${{ env.VERSION }}"}'
+
+      - uses: arustydev/gha/actions/attestation/create@v1
+        id: attest
+        with:
+          subject-name: lint-my-chart-${{ env.VERSION }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          pr-number: ${{ github.event.pull_request.number }}
+          check-name: lint-test-${{ env.VERSION }}
+```
+
+## Behavior
+
+- Wraps `actions/attest-build-provenance@v2`
+- Optionally updates PR attestation map if both `pr-number` and `check-name` are provided
+- Logs detailed attestation information for debugging
+- Provides consistent interface with other attestation actions

--- a/actions/attestation/create/action.yml
+++ b/actions/attestation/create/action.yml
@@ -1,0 +1,84 @@
+name: "Create Attestation"
+description: "Create attestation with optional PR map update"
+author: "aRustyDev"
+
+branding:
+  icon: "shield"
+  color: "green"
+
+inputs:
+  subject-name:
+    description: "Name for the attestation subject"
+    required: true
+  subject-digest:
+    description: "SHA256 digest of the subject"
+    required: true
+  pr-number:
+    description: "PR number to update attestation map (optional)"
+    required: false
+    default: ""
+  check-name:
+    description: "Check name for attestation map entry (optional)"
+    required: false
+    default: ""
+  push-to-registry:
+    description: "Push attestation to GHCR"
+    required: false
+    default: "false"
+  token:
+    description: "GitHub token"
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  attestation-id:
+    description: "The generated attestation ID"
+    value: ${{ steps.attest.outputs.attestation-id }}
+  bundle-path:
+    description: "Path to the attestation bundle"
+    value: ${{ steps.attest.outputs.bundle-path }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create attestation
+      id: attest
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ${{ inputs.subject-name }}
+        subject-digest: ${{ inputs.subject-digest }}
+        push-to-registry: ${{ inputs.push-to-registry }}
+
+    - name: Update PR attestation map
+      if: inputs.pr-number != '' && inputs.check-name != ''
+      uses: arustydev/gha/actions/attestation/update-pr-map@main
+      with:
+        pr-number: ${{ inputs.pr-number }}
+        check-name: ${{ inputs.check-name }}
+        attestation-id: ${{ steps.attest.outputs.attestation-id }}
+        token: ${{ inputs.token }}
+
+    - name: Log attestation details
+      shell: bash
+      env:
+        SUBJECT_NAME: ${{ inputs.subject-name }}
+        SUBJECT_DIGEST: ${{ inputs.subject-digest }}
+        ATTESTATION_ID: ${{ steps.attest.outputs.attestation-id }}
+        BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        CHECK_NAME: ${{ inputs.check-name }}
+      run: |
+        set -euo pipefail
+
+        echo "::group::Attestation Details"
+        echo "Subject Name: $SUBJECT_NAME"
+        echo "Subject Digest: $SUBJECT_DIGEST"
+        echo "Attestation ID: $ATTESTATION_ID"
+        echo "Bundle Path: $BUNDLE_PATH"
+        echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        if [[ -n "$PR_NUMBER" && -n "$CHECK_NAME" ]]; then
+          echo "PR Number: $PR_NUMBER"
+          echo "Check Name: $CHECK_NAME"
+          echo "::notice::Attestation map updated for PR #$PR_NUMBER"
+        fi
+        echo "::endgroup::"

--- a/actions/attestation/extract-map/README.md
+++ b/actions/attestation/extract-map/README.md
@@ -1,0 +1,76 @@
+# attestation/extract-map
+
+Extract attestation map from PR description.
+
+The attestation map is stored in PR descriptions using HTML comments:
+
+```html
+<!-- ATTESTATION_MAP
+{"lint-test-v1.32.11": "attestation-id-1", "install-test-v1.32.11": "attestation-id-2"}
+-->
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `pr-number` | Yes | - | PR number to extract from |
+| `body` | No | - | Alternative: PR body content (if already fetched) |
+| `token` | No | `github.token` | GitHub token for API access |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `map` | JSON object of check_name to attestation_id |
+| `count` | Number of entries in the map |
+| `empty` | `true` if map is empty, `false` otherwise |
+
+## Usage
+
+### Basic Usage
+
+```yaml
+- uses: arustydev/gha/actions/attestation/extract-map@v1
+  id: attestation
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+
+- run: echo "Found ${{ steps.attestation.outputs.count }} attestations"
+```
+
+### With Pre-fetched Body
+
+```yaml
+- name: Get PR body
+  id: pr
+  run: echo "body=$(gh pr view ${{ github.event.pull_request.number }} --json body -q '.body')" >> "$GITHUB_OUTPUT"
+
+- uses: arustydev/gha/actions/attestation/extract-map@v1
+  id: attestation
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+    body: ${{ steps.pr.outputs.body }}
+```
+
+### Check If Empty
+
+```yaml
+- uses: arustydev/gha/actions/attestation/extract-map@v1
+  id: attestation
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+
+- name: Verify attestations exist
+  if: steps.attestation.outputs.empty == 'true'
+  run: |
+    echo "::error::No attestations found in PR"
+    exit 1
+```
+
+## Behavior
+
+- Returns empty JSON object `{}` if no map found
+- Returns empty JSON object `{}` if map contains invalid JSON
+- Handles missing or malformed attestation maps gracefully
+- Validates JSON before returning

--- a/actions/attestation/extract-map/action.yml
+++ b/actions/attestation/extract-map/action.yml
@@ -1,0 +1,100 @@
+name: "Extract Attestation Map"
+description: "Extract attestation map from PR description"
+author: "aRustyDev"
+
+branding:
+  icon: "file-text"
+  color: "blue"
+
+inputs:
+  pr-number:
+    description: "PR number to extract attestation map from"
+    required: true
+  body:
+    description: "Alternative: PR body content (if already fetched)"
+    required: false
+    default: ""
+  token:
+    description: "GitHub token for API access"
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  map:
+    description: "JSON object of check_name to attestation_id"
+    value: ${{ steps.extract.outputs.map }}
+  count:
+    description: "Number of entries in the map"
+    value: ${{ steps.extract.outputs.count }}
+  empty:
+    description: "true if map is empty, false otherwise"
+    value: ${{ steps.extract.outputs.empty }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract attestation map
+      id: extract
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        PR_BODY: ${{ inputs.body }}
+      run: |
+        set -euo pipefail
+
+        # Get PR body either from input or API
+        if [[ -n "$PR_BODY" ]]; then
+          body="$PR_BODY"
+        else
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "::error::PR number is required when body is not provided"
+            exit 1
+          fi
+
+          body=$(gh pr view "$PR_NUMBER" --json body -q '.body' 2>/dev/null) || {
+            echo "::error::Failed to fetch PR body for PR #$PR_NUMBER"
+            exit 1
+          }
+        fi
+
+        # Extract content between attestation map markers
+        if [[ -z "$body" ]]; then
+          echo "::notice::PR body is empty, returning empty map"
+          map='{}'
+        else
+          # Extract content between markers using awk
+          map_content=$(echo "$body" | awk '
+            /<!-- ATTESTATION_MAP/,/-->/ {
+              if (!/<!-- ATTESTATION_MAP/ && !/-->/) print
+            }
+          ' | tr -d '\n' | xargs 2>/dev/null || echo "")
+
+          if [[ -z "$map_content" ]]; then
+            echo "::notice::No attestation map found in PR description"
+            map='{}'
+          else
+            # Validate JSON
+            if echo "$map_content" | jq -e . >/dev/null 2>&1; then
+              map="$map_content"
+            else
+              echo "::warning::Invalid JSON in attestation map, returning empty"
+              map='{}'
+            fi
+          fi
+        fi
+
+        # Calculate count and empty flag
+        count=$(echo "$map" | jq 'length')
+        if [[ "$count" -eq 0 ]]; then
+          empty="true"
+        else
+          empty="false"
+        fi
+
+        echo "::notice::Extracted attestation map with $count entries"
+
+        # Output results
+        echo "map=$map" >> "$GITHUB_OUTPUT"
+        echo "count=$count" >> "$GITHUB_OUTPUT"
+        echo "empty=$empty" >> "$GITHUB_OUTPUT"

--- a/actions/attestation/generate-digest/README.md
+++ b/actions/attestation/generate-digest/README.md
@@ -1,0 +1,77 @@
+# attestation/generate-digest
+
+Generate SHA256/SHA512 digest for attestation subject.
+
+Supports both file content and string content for flexible attestation subjects.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `content` | Yes | - | Content to hash (file path or string) |
+| `type` | No | `string` | Content type: `file` or `string` |
+| `algorithm` | No | `sha256` | Hash algorithm: `sha256` or `sha512` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `digest` | Digest in format `algorithm:hash` (e.g., `sha256:abc123...`) |
+
+## Usage
+
+### Hash a String
+
+```yaml
+- uses: arustydev/gha/actions/attestation/generate-digest@v1
+  id: digest
+  with:
+    content: '{"workflow": "atomize", "artifacts": ["chart-a", "chart-b"]}'
+    type: string
+
+- run: echo "Digest: ${{ steps.digest.outputs.digest }}"
+```
+
+### Hash a File
+
+```yaml
+- uses: arustydev/gha/actions/attestation/generate-digest@v1
+  id: file-digest
+  with:
+    content: charts/my-chart/Chart.yaml
+    type: file
+
+- run: echo "File digest: ${{ steps.file-digest.outputs.digest }}"
+```
+
+### Use SHA512
+
+```yaml
+- uses: arustydev/gha/actions/attestation/generate-digest@v1
+  id: digest
+  with:
+    content: charts/my-chart/Chart.yaml
+    type: file
+    algorithm: sha512
+```
+
+### Use with Attestation Create
+
+```yaml
+- uses: arustydev/gha/actions/attestation/generate-digest@v1
+  id: digest
+  with:
+    content: '{"chart": "my-chart", "version": "1.2.3"}'
+    type: string
+
+- uses: arustydev/gha/actions/attestation/create@v1
+  with:
+    subject-name: my-chart-v1.2.3
+    subject-digest: ${{ steps.digest.outputs.digest }}
+```
+
+## Behavior
+
+- Validates file exists when `type=file`
+- Output format is always `algorithm:hash`
+- Fails with error if file not found or invalid algorithm

--- a/actions/attestation/generate-digest/action.yml
+++ b/actions/attestation/generate-digest/action.yml
@@ -1,0 +1,75 @@
+name: "Generate Attestation Digest"
+description: "Generate SHA256 digest for attestation subject"
+author: "aRustyDev"
+
+branding:
+  icon: "hash"
+  color: "blue"
+
+inputs:
+  content:
+    description: "Content to hash (file path or string)"
+    required: true
+  type:
+    description: "Content type: 'file' or 'string'"
+    required: false
+    default: "string"
+  algorithm:
+    description: "Hash algorithm: 'sha256' or 'sha512'"
+    required: false
+    default: "sha256"
+
+outputs:
+  digest:
+    description: "Digest in format 'algorithm:hash'"
+    value: ${{ steps.hash.outputs.digest }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate digest
+      id: hash
+      shell: bash
+      env:
+        CONTENT: ${{ inputs.content }}
+        TYPE: ${{ inputs.type }}
+        ALGORITHM: ${{ inputs.algorithm }}
+      run: |
+        set -euo pipefail
+
+        # Validate algorithm
+        case "$ALGORITHM" in
+          sha256|sha512)
+            ;;
+          *)
+            echo "::error::Invalid algorithm: $ALGORITHM (must be sha256 or sha512)"
+            exit 1
+            ;;
+        esac
+
+        # Select hash command
+        case "$ALGORITHM" in
+          sha256)
+            hash_cmd="sha256sum"
+            ;;
+          sha512)
+            hash_cmd="sha512sum"
+            ;;
+        esac
+
+        # Generate hash based on type
+        if [[ "$TYPE" == "file" ]]; then
+          if [[ ! -f "$CONTENT" ]]; then
+            echo "::error::File not found: $CONTENT"
+            exit 1
+          fi
+          hash=$($hash_cmd "$CONTENT" | cut -d' ' -f1)
+          echo "::notice::Generated $ALGORITHM digest for file: $CONTENT"
+        else
+          hash=$(echo -n "$CONTENT" | $hash_cmd | cut -d' ' -f1)
+          echo "::notice::Generated $ALGORITHM digest for string content"
+        fi
+
+        digest="${ALGORITHM}:${hash}"
+        echo "digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "::notice::Digest: $digest"

--- a/actions/attestation/update-pr-map/README.md
+++ b/actions/attestation/update-pr-map/README.md
@@ -1,0 +1,87 @@
+# attestation/update-pr-map
+
+Update attestation map in PR description.
+
+Adds or updates an attestation ID for a given check name in the PR description,
+using HTML comments:
+
+```html
+<!-- ATTESTATION_MAP
+{"lint-test-v1.32.11": "attestation-id-1", "install-test-v1.32.11": "attestation-id-2"}
+-->
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `pr-number` | Yes | - | PR number to update |
+| `check-name` | Yes | - | Name of the check (e.g., `lint-test-v1.32.11`) |
+| `attestation-id` | Yes | - | The attestation ID to store |
+| `action` | No | `add` | Action to perform: `add` or `remove` |
+| `token` | No | `github.token` | GitHub token for API access |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `updated` | `true` if successfully updated |
+| `map` | Updated JSON object |
+
+## Usage
+
+### Add Attestation
+
+```yaml
+- uses: arustydev/gha/actions/attestation/update-pr-map@v1
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+    check-name: "lint-test-v1.32.11"
+    attestation-id: ${{ steps.attest.outputs.attestation-id }}
+```
+
+### Remove Attestation
+
+```yaml
+- uses: arustydev/gha/actions/attestation/update-pr-map@v1
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+    check-name: "lint-test-v1.32.11"
+    attestation-id: ""
+    action: remove
+```
+
+### With Custom Token
+
+```yaml
+- uses: arustydev/gha/actions/attestation/update-pr-map@v1
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+    check-name: "install-test-v1.32.11"
+    attestation-id: ${{ steps.attest.outputs.attestation-id }}
+    token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Check Update Status
+
+```yaml
+- uses: arustydev/gha/actions/attestation/update-pr-map@v1
+  id: update
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+    check-name: "lint-test"
+    attestation-id: ${{ steps.attest.outputs.attestation-id }}
+
+- name: Verify update
+  if: steps.update.outputs.updated != 'true'
+  run: |
+    echo "::error::Failed to update attestation map"
+    exit 1
+```
+
+## Behavior
+
+- Uses exponential backoff retry for concurrent updates (5 retries max)
+- Creates map section if it doesn't exist
+- Preserves existing attestations when adding new ones
+- Handles race conditions with concurrent PR updates

--- a/actions/attestation/update-pr-map/action.yml
+++ b/actions/attestation/update-pr-map/action.yml
@@ -1,0 +1,144 @@
+name: "Update PR Attestation Map"
+description: "Update attestation map in PR description"
+author: "aRustyDev"
+
+branding:
+  icon: "edit"
+  color: "blue"
+
+inputs:
+  pr-number:
+    description: "PR number to update"
+    required: true
+  check-name:
+    description: "Name of the check (e.g., 'lint-test-v1.32.11')"
+    required: true
+  attestation-id:
+    description: "The attestation ID to store"
+    required: true
+  action:
+    description: "Action to perform: 'add' or 'remove'"
+    required: false
+    default: "add"
+  token:
+    description: "GitHub token for API access"
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  updated:
+    description: "true if successfully updated"
+    value: ${{ steps.update.outputs.updated }}
+  map:
+    description: "Updated JSON object"
+    value: ${{ steps.update.outputs.map }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Update attestation map
+      id: update
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        CHECK_NAME: ${{ inputs.check-name }}
+        ATTESTATION_ID: ${{ inputs.attestation-id }}
+        ACTION: ${{ inputs.action }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$PR_NUMBER" ]]; then
+          echo "::error::PR number is required"
+          exit 1
+        fi
+
+        if [[ -z "$CHECK_NAME" ]]; then
+          echo "::error::check-name is required"
+          exit 1
+        fi
+
+        if [[ "$ACTION" == "add" && -z "$ATTESTATION_ID" ]]; then
+          echo "::error::attestation-id is required for add action"
+          exit 1
+        fi
+
+        max_retries=5
+        retry_delay=1
+
+        for ((attempt = 1; attempt <= max_retries; attempt++)); do
+          echo "::debug::Updating attestation map (attempt $attempt/$max_retries)"
+
+          # Get current PR body
+          body=$(gh pr view "$PR_NUMBER" --json body -q '.body' 2>/dev/null) || {
+            echo "::warning::Failed to fetch PR body, retrying..."
+            sleep "$retry_delay"
+            retry_delay=$((retry_delay * 2))
+            continue
+          }
+
+          # Extract existing map or create new one
+          existing_map=$(echo "$body" | awk '
+            /<!-- ATTESTATION_MAP/,/-->/ {
+              if (!/<!-- ATTESTATION_MAP/ && !/-->/) print
+            }
+          ' | tr -d '\n' | xargs 2>/dev/null || echo "{}")
+
+          if [[ -z "$existing_map" ]] || ! echo "$existing_map" | jq -e . >/dev/null 2>&1; then
+            existing_map='{}'
+          fi
+
+          # Update map based on action
+          if [[ "$ACTION" == "add" ]]; then
+            updated_map=$(echo "$existing_map" | jq -c --arg k "$CHECK_NAME" --arg v "$ATTESTATION_ID" '. + {($k): $v}')
+          elif [[ "$ACTION" == "remove" ]]; then
+            updated_map=$(echo "$existing_map" | jq -c --arg k "$CHECK_NAME" 'del(.[$k])')
+          else
+            echo "::error::Invalid action: $ACTION (must be 'add' or 'remove')"
+            exit 1
+          fi
+
+          # Build new body
+          if echo "$body" | grep -qF "<!-- ATTESTATION_MAP"; then
+            # Replace existing map using awk
+            new_body=$(echo "$body" | awk -v map="$updated_map" '
+              /<!-- ATTESTATION_MAP/,/-->/ {
+                if (/<!-- ATTESTATION_MAP/) {
+                  print "<!-- ATTESTATION_MAP"
+                  print map
+                  next
+                }
+                if (/-->/) {
+                  print "-->"
+                  next
+                }
+                next
+              }
+              { print }
+            ')
+          else
+            # Append new map section
+            new_body="$body
+
+<!-- ATTESTATION_MAP
+$updated_map
+-->"
+          fi
+
+          # Update PR
+          if gh pr edit "$PR_NUMBER" --body "$new_body" 2>/dev/null; then
+            echo "::notice::Updated attestation map: $CHECK_NAME = $ATTESTATION_ID (action: $ACTION)"
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "map=$updated_map" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::warning::Failed to update PR body, retrying..."
+          sleep "$retry_delay"
+          retry_delay=$((retry_delay * 2))
+        done
+
+        echo "::error::Failed to update attestation map after $max_retries attempts"
+        echo "updated=false" >> "$GITHUB_OUTPUT"
+        echo "map={}" >> "$GITHUB_OUTPUT"
+        exit 1

--- a/actions/attestation/verify-chain/README.md
+++ b/actions/attestation/verify-chain/README.md
@@ -1,0 +1,116 @@
+# attestation/verify-chain
+
+Verify all attestations in a chain.
+
+Iterates through an attestation map and verifies each attestation is valid
+and was created by the expected repository.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `attestation-map` | Yes | - | JSON object of check_name to attestation_id |
+| `repository` | No | `github.repository` | Repository in owner/repo format |
+| `fail-fast` | No | `false` | Stop on first failure |
+| `token` | No | `github.token` | GitHub token for API access |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `verified` | `true` if all attestations valid |
+| `total` | Total number of attestations checked |
+| `passed` | Number that passed verification |
+| `failed` | Number that failed verification |
+| `results-json` | Detailed JSON results for each attestation |
+
+## Usage
+
+### Basic Verification
+
+```yaml
+- uses: arustydev/gha/actions/attestation/extract-map@v1
+  id: extract
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+
+- uses: arustydev/gha/actions/attestation/verify-chain@v1
+  id: verify
+  with:
+    attestation-map: ${{ steps.extract.outputs.map }}
+
+- run: |
+    if [[ "${{ steps.verify.outputs.verified }}" != "true" ]]; then
+      echo "Attestation chain verification failed!"
+      exit 1
+    fi
+```
+
+### With Fail-Fast
+
+```yaml
+- uses: arustydev/gha/actions/attestation/verify-chain@v1
+  id: verify
+  with:
+    attestation-map: ${{ steps.extract.outputs.map }}
+    fail-fast: true
+```
+
+### Custom Repository
+
+```yaml
+- uses: arustydev/gha/actions/attestation/verify-chain@v1
+  id: verify
+  with:
+    attestation-map: ${{ steps.extract.outputs.map }}
+    repository: arustydev/helm-charts
+```
+
+### Process Detailed Results
+
+```yaml
+- uses: arustydev/gha/actions/attestation/verify-chain@v1
+  id: verify
+  with:
+    attestation-map: ${{ steps.extract.outputs.map }}
+
+- name: Show results
+  run: |
+    echo "Total: ${{ steps.verify.outputs.total }}"
+    echo "Passed: ${{ steps.verify.outputs.passed }}"
+    echo "Failed: ${{ steps.verify.outputs.failed }}"
+    echo "Details: ${{ steps.verify.outputs.results-json }}"
+```
+
+## Results JSON Format
+
+The `results-json` output contains an array of verification results:
+
+```json
+[
+  {
+    "check_name": "lint-test-v1.32.11",
+    "attestation_id": "abc123",
+    "status": "passed",
+    "method": "oci"
+  },
+  {
+    "check_name": "install-test-v1.32.11",
+    "attestation_id": "def456",
+    "status": "passed",
+    "method": "api"
+  }
+]
+```
+
+## Verification Methods
+
+1. **OCI Bundle** (preferred): Verifies using `gh attestation verify --bundle-from-oci`
+2. **API** (fallback): Verifies using GitHub REST API
+
+## Behavior
+
+- Tries OCI bundle verification first, falls back to API
+- Reports detailed results for each attestation
+- With `fail-fast: true`, stops on first verification failure
+- With `fail-fast: false` (default), continues and reports all failures

--- a/actions/attestation/verify-chain/action.yml
+++ b/actions/attestation/verify-chain/action.yml
@@ -1,0 +1,149 @@
+name: "Verify Attestation Chain"
+description: "Verify all attestations in a chain"
+author: "aRustyDev"
+
+branding:
+  icon: "check-circle"
+  color: "green"
+
+inputs:
+  attestation-map:
+    description: "JSON object of check_name to attestation_id"
+    required: true
+  repository:
+    description: "Repository in owner/repo format"
+    required: false
+    default: ${{ github.repository }}
+  fail-fast:
+    description: "Stop on first failure"
+    required: false
+    default: "false"
+  token:
+    description: "GitHub token for API access"
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  verified:
+    description: "true if all attestations valid"
+    value: ${{ steps.verify.outputs.verified }}
+  total:
+    description: "Total number of attestations checked"
+    value: ${{ steps.verify.outputs.total }}
+  passed:
+    description: "Number that passed verification"
+    value: ${{ steps.verify.outputs.passed }}
+  failed:
+    description: "Number that failed verification"
+    value: ${{ steps.verify.outputs.failed }}
+  results-json:
+    description: "Detailed JSON results for each attestation"
+    value: ${{ steps.verify.outputs.results_json }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Verify attestation chain
+      id: verify
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        ATTESTATION_MAP: ${{ inputs.attestation-map }}
+        REPOSITORY: ${{ inputs.repository }}
+        FAIL_FAST: ${{ inputs.fail-fast }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$REPOSITORY" ]]; then
+          echo "::error::Repository not provided"
+          exit 1
+        fi
+
+        if [[ -z "$ATTESTATION_MAP" || "$ATTESTATION_MAP" == "{}" ]]; then
+          echo "::error::Empty attestation map provided"
+          echo "verified=false" >> "$GITHUB_OUTPUT"
+          echo "total=0" >> "$GITHUB_OUTPUT"
+          echo "passed=0" >> "$GITHUB_OUTPUT"
+          echo "failed=0" >> "$GITHUB_OUTPUT"
+          echo 'results_json=[]' >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+
+        # Validate JSON
+        if ! echo "$ATTESTATION_MAP" | jq -e . >/dev/null 2>&1; then
+          echo "::error::Invalid JSON in attestation map"
+          exit 1
+        fi
+
+        failed=0
+        total=0
+        verified=0
+        results="[]"
+
+        # Iterate through all attestations
+        while IFS='=' read -r key value; do
+          ((total++))
+          check_name=$(echo "$key" | tr -d '"')
+          attestation_id=$(echo "$value" | tr -d '"')
+
+          echo "::group::Verifying attestation: $check_name"
+          echo "Attestation ID: $attestation_id"
+
+          verification_status="failed"
+          verification_method=""
+
+          # Try OCI bundle verification first
+          if gh attestation verify \
+              --repo "$REPOSITORY" \
+              --bundle-from-oci "oci://ghcr.io/$REPOSITORY/attestations:$attestation_id" 2>/dev/null; then
+            echo "::notice::Verified via OCI: $check_name"
+            verification_status="passed"
+            verification_method="oci"
+            ((verified++))
+          else
+            # Try API verification as fallback
+            if gh api "/repos/$REPOSITORY/attestations/$attestation_id" >/dev/null 2>&1; then
+              echo "::notice::Verified via API: $check_name"
+              verification_status="passed"
+              verification_method="api"
+              ((verified++))
+            else
+              echo "::error::Failed to verify: $check_name ($attestation_id)"
+              ((failed++))
+
+              if [[ "$FAIL_FAST" == "true" ]]; then
+                echo "::endgroup::"
+                echo "::error::Fail-fast enabled, stopping verification"
+                echo "verified=false" >> "$GITHUB_OUTPUT"
+                echo "total=$total" >> "$GITHUB_OUTPUT"
+                echo "passed=$verified" >> "$GITHUB_OUTPUT"
+                echo "failed=$failed" >> "$GITHUB_OUTPUT"
+                echo "results_json=$results" >> "$GITHUB_OUTPUT"
+                exit 1
+              fi
+            fi
+          fi
+
+          # Add to results
+          results=$(echo "$results" | jq -c \
+            --arg name "$check_name" \
+            --arg id "$attestation_id" \
+            --arg status "$verification_status" \
+            --arg method "$verification_method" \
+            '. + [{"check_name": $name, "attestation_id": $id, "status": $status, "method": $method}]')
+
+          echo "::endgroup::"
+        done < <(echo "$ATTESTATION_MAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"')
+
+        echo "::notice::Attestation verification complete: $verified/$total verified, $failed failed"
+
+        if [[ $failed -gt 0 ]]; then
+          echo "verified=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "verified=true" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "total=$total" >> "$GITHUB_OUTPUT"
+        echo "passed=$verified" >> "$GITHUB_OUTPUT"
+        echo "failed=$failed" >> "$GITHUB_OUTPUT"
+        echo "results_json=$results" >> "$GITHUB_OUTPUT"

--- a/actions/changelog/extract-version/README.md
+++ b/actions/changelog/extract-version/README.md
@@ -1,0 +1,137 @@
+# changelog/extract-version
+
+Extract changelog entries for a specific version from a Keep-a-Changelog format file.
+
+## Description
+
+This action reads a CHANGELOG.md file and extracts the section for a given version. It supports the [Keep a Changelog](https://keepachangelog.com/) format and can parse:
+
+- Version headers with dates (`## [1.2.3] - 2024-01-15`)
+- Version headers with comparison URLs (`## [1.2.3](https://github.com/org/repo/compare/v1.2.2...v1.2.3)`)
+- Unreleased sections (`## [Unreleased]`)
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `changelog-path` | Yes | - | Path to CHANGELOG.md file |
+| `version` | Yes | - | Version to extract (e.g., "1.2.3" or "unreleased") |
+| `format` | No | `auto` | Changelog format: `keep-a-changelog`, `conventional`, or `auto` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `content` | Changelog content for the version (without the header) |
+| `found` | Whether the version section was found (`true`/`false`) |
+| `date` | Release date if present in the header (YYYY-MM-DD format) |
+| `compare-url` | Comparison URL if present in the header |
+| `previous-version` | Previous version parsed from comparison URL |
+
+## Usage Examples
+
+### Basic Usage
+
+```yaml
+- uses: arustydev/gha/actions/changelog/extract-version@v1
+  id: changelog
+  with:
+    changelog-path: CHANGELOG.md
+    version: "1.3.0"
+
+- run: |
+    if [[ "${{ steps.changelog.outputs.found }}" == "true" ]]; then
+      echo "Release notes for v1.3.0:"
+      echo "${{ steps.changelog.outputs.content }}"
+    else
+      echo "No changelog entry found for v1.3.0"
+    fi
+```
+
+### Extract Unreleased Changes
+
+```yaml
+- uses: arustydev/gha/actions/changelog/extract-version@v1
+  id: unreleased
+  with:
+    changelog-path: CHANGELOG.md
+    version: "unreleased"
+
+- run: |
+    echo "Pending changes:"
+    echo "${{ steps.unreleased.outputs.content }}"
+```
+
+### Use in Release Workflow
+
+```yaml
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: arustydev/gha/actions/changelog/extract-version@v1
+        id: changelog
+        with:
+          changelog-path: charts/my-chart/CHANGELOG.md
+          version: ${{ github.event.inputs.version }}
+
+      - name: Create GitHub Release
+        if: steps.changelog.outputs.found == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          body: ${{ steps.changelog.outputs.content }}
+```
+
+### With Helm Charts
+
+```yaml
+- uses: arustydev/gha/actions/changelog/extract-version@v1
+  id: changelog
+  with:
+    changelog-path: charts/${{ matrix.chart }}/CHANGELOG.md
+    version: ${{ steps.version.outputs.new_version }}
+
+- name: Display release date
+  if: steps.changelog.outputs.date != ''
+  run: echo "Released on: ${{ steps.changelog.outputs.date }}"
+```
+
+## Changelog Format
+
+This action expects the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- New feature pending release
+
+## [1.2.3] - 2024-01-15
+
+### Added
+- New feature X
+
+### Fixed
+- Bug fix Y
+
+## [1.2.2](https://github.com/org/repo/compare/v1.2.1...v1.2.2) - 2024-01-10
+
+### Changed
+- Updated dependency Z
+```
+
+## Related Actions
+
+- [changelog/generate](../generate) - Generate changelog from commits
+- [changelog/update](../update) - Update CHANGELOG.md with new version section
+
+## License
+
+MIT

--- a/actions/changelog/extract-version/action.yml
+++ b/actions/changelog/extract-version/action.yml
@@ -1,0 +1,135 @@
+name: "Extract Changelog for Version"
+description: "Extract changelog entries for a specific version from a Keep-a-Changelog format file"
+author: "aRustyDev"
+
+branding:
+  icon: "file-text"
+  color: "blue"
+
+inputs:
+  changelog-path:
+    description: "Path to CHANGELOG.md file"
+    required: true
+  version:
+    description: 'Version to extract (e.g., "1.2.3" or "unreleased")'
+    required: true
+  format:
+    description: "Changelog format: keep-a-changelog, conventional, or auto"
+    required: false
+    default: "auto"
+
+outputs:
+  content:
+    description: "Changelog content for the version (without the header)"
+    value: ${{ steps.extract.outputs.content }}
+  found:
+    description: "Whether the version section was found (true/false)"
+    value: ${{ steps.extract.outputs.found }}
+  date:
+    description: "Release date if present in the header"
+    value: ${{ steps.extract.outputs.date }}
+  compare-url:
+    description: "Comparison URL if present in the header"
+    value: ${{ steps.extract.outputs.compare_url }}
+  previous-version:
+    description: "Previous version if comparison URL was parsed"
+    value: ${{ steps.extract.outputs.previous_version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract changelog section
+      id: extract
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        CHANGELOG_PATH="${{ inputs.changelog-path }}"
+        VERSION="${{ inputs.version }}"
+        FORMAT="${{ inputs.format }}"
+
+        # Validate inputs
+        if [[ ! -f "$CHANGELOG_PATH" ]]; then
+          echo "::warning::Changelog file not found: $CHANGELOG_PATH"
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          echo "content=" >> "$GITHUB_OUTPUT"
+          echo "date=" >> "$GITHUB_OUTPUT"
+          echo "compare_url=" >> "$GITHUB_OUTPUT"
+          echo "previous_version=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Normalize version input
+        VERSION_PATTERN="$VERSION"
+        if [[ "${VERSION,,}" == "unreleased" ]]; then
+          VERSION_PATTERN="Unreleased"
+        fi
+
+        echo "::debug::Extracting version $VERSION_PATTERN from $CHANGELOG_PATH"
+
+        # Extract the section for this version
+        # Handles both [VERSION] and [VERSION] - DATE formats
+        SECTION=$(awk -v ver="$VERSION_PATTERN" '
+          BEGIN { found=0; in_section=0 }
+          /^## \[/ {
+            if (in_section) { exit }
+            # Match version (case-insensitive for Unreleased)
+            if (tolower($0) ~ "\\[" tolower(ver) "\\]") {
+              found=1
+              in_section=1
+              header=$0
+              next
+            }
+          }
+          in_section { content = content $0 "\n" }
+          END {
+            if (found) {
+              print "HEADER:" header
+              print "CONTENT:" content
+            }
+          }
+        ' "$CHANGELOG_PATH")
+
+        if [[ -z "$SECTION" ]]; then
+          echo "::notice::Version $VERSION not found in changelog"
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          echo "content=" >> "$GITHUB_OUTPUT"
+          echo "date=" >> "$GITHUB_OUTPUT"
+          echo "compare_url=" >> "$GITHUB_OUTPUT"
+          echo "previous_version=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Parse header and content
+        HEADER=$(echo "$SECTION" | grep "^HEADER:" | sed 's/^HEADER://')
+        CONTENT=$(echo "$SECTION" | sed -n '/^CONTENT:/,$p' | sed '1s/^CONTENT://' | sed '/^$/d')
+
+        # Extract date from header (format: ## [VERSION] - YYYY-MM-DD)
+        DATE=""
+        if [[ "$HEADER" =~ -[[:space:]]*([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
+          DATE="${BASH_REMATCH[1]}"
+        fi
+
+        # Extract comparison URL if present (format: ## [VERSION](URL))
+        COMPARE_URL=""
+        PREVIOUS_VERSION=""
+        if [[ "$HEADER" =~ \]\(([^)]+)\) ]]; then
+          COMPARE_URL="${BASH_REMATCH[1]}"
+          # Try to extract previous version from compare URL
+          if [[ "$COMPARE_URL" =~ compare/v?([0-9]+\.[0-9]+\.[0-9]+)\.\.\.v?([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            PREVIOUS_VERSION="${BASH_REMATCH[1]}"
+          fi
+        fi
+
+        echo "::notice::Found changelog section for version $VERSION"
+        echo "found=true" >> "$GITHUB_OUTPUT"
+        echo "date=$DATE" >> "$GITHUB_OUTPUT"
+        echo "compare_url=$COMPARE_URL" >> "$GITHUB_OUTPUT"
+        echo "previous_version=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
+
+        # Handle multiline content output
+        {
+          echo "content<<EOF"
+          echo "$CONTENT"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"

--- a/actions/changelog/generate/README.md
+++ b/actions/changelog/generate/README.md
@@ -1,0 +1,186 @@
+# changelog/generate
+
+Generate changelog entries from conventional commits using git-cliff.
+
+## Description
+
+This action analyzes commits since a base reference and generates a changelog entry for a specific artifact. It uses [git-cliff](https://github.com/orhun/git-cliff) for intelligent changelog generation from conventional commits, with a fallback to simple commit grouping if git-cliff is unavailable or fails.
+
+## Features
+
+- Filters commits by artifact path
+- Groups commits by type (feat, fix, etc.)
+- Supports custom git-cliff configuration
+- Fallback to simple changelog if git-cliff fails
+- Outputs in markdown or JSON format
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `artifact` | Yes | - | Artifact name (used to filter commits by path) |
+| `artifact-path` | Yes | - | Path to artifacts directory (e.g., "charts" for Helm charts) |
+| `version` | Yes | - | Version for the changelog entry (e.g., "1.3.0") |
+| `base-ref` | No | `origin/main` | Base ref for commit range comparison |
+| `config` | No | `cliff.toml` | Path to git-cliff configuration file |
+| `output-format` | No | `markdown` | Output format: `markdown` or `json` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `changelog` | Generated changelog content |
+| `commits-analyzed` | Number of commits analyzed |
+
+## Usage Examples
+
+### Basic Usage
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0  # Required for git log
+
+- uses: arustydev/gha/actions/changelog/generate@v1
+  id: changelog
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    version: "1.3.0"
+
+- run: echo "${{ steps.changelog.outputs.changelog }}"
+```
+
+### With Custom Base Reference
+
+```yaml
+- uses: arustydev/gha/actions/changelog/generate@v1
+  id: changelog
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    version: "1.3.0"
+    base-ref: "origin/integration"
+```
+
+### With Custom git-cliff Config
+
+```yaml
+- uses: arustydev/gha/actions/changelog/generate@v1
+  id: changelog
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    version: "1.3.0"
+    config: ".github/cliff.toml"
+```
+
+### Complete Workflow Example
+
+```yaml
+name: Generate Release Notes
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from Chart.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' charts/my-chart/Chart.yaml | awk '{print $2}')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: arustydev/gha/actions/changelog/generate@v1
+        id: changelog
+        with:
+          artifact: my-chart
+          artifact-path: charts
+          version: ${{ steps.version.outputs.version }}
+
+      - name: Update CHANGELOG.md
+        uses: arustydev/gha/actions/changelog/update@v1
+        with:
+          changelog-path: charts/my-chart/CHANGELOG.md
+          version: ${{ steps.version.outputs.version }}
+          content: ${{ steps.changelog.outputs.changelog }}
+```
+
+### JSON Output Format
+
+```yaml
+- uses: arustydev/gha/actions/changelog/generate@v1
+  id: changelog
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    version: "1.3.0"
+    output-format: json
+
+- name: Parse JSON changelog
+  run: |
+    echo '${{ steps.changelog.outputs.changelog }}' | jq -r .
+```
+
+## git-cliff Configuration
+
+If you provide a custom git-cliff config, it should follow the [git-cliff format](https://git-cliff.org/docs/configuration). Example `cliff.toml`:
+
+```toml
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}\
+{% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactored" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+]
+```
+
+## Fallback Behavior
+
+If git-cliff is not available or produces no output, the action falls back to a simple changelog generator that:
+
+1. Groups commits by conventional commit type
+2. Creates `### Added` section for `feat:` commits
+3. Creates `### Fixed` section for `fix:` commits
+4. Creates `### Changed` section for all other commits
+
+## Requirements
+
+- Git repository with conventional commits
+- `fetch-depth: 0` in checkout action (for full git history)
+
+## Related Actions
+
+- [changelog/extract-version](../extract-version) - Extract changelog for a version
+- [changelog/update](../update) - Update CHANGELOG.md with new version section
+
+## License
+
+MIT

--- a/actions/changelog/generate/action.yml
+++ b/actions/changelog/generate/action.yml
@@ -1,0 +1,193 @@
+name: "Generate Changelog from Commits"
+description: "Generate changelog entries from conventional commits using git-cliff"
+author: "aRustyDev"
+
+branding:
+  icon: "git-commit"
+  color: "green"
+
+inputs:
+  artifact:
+    description: "Artifact name (used to filter commits by path)"
+    required: true
+  artifact-path:
+    description: "Path to artifacts directory (e.g., 'charts' for Helm charts)"
+    required: true
+  version:
+    description: "Version for the changelog entry (e.g., '1.3.0')"
+    required: true
+  base-ref:
+    description: "Base ref for commit range comparison"
+    required: false
+    default: "origin/main"
+  config:
+    description: "Path to git-cliff configuration file"
+    required: false
+    default: "cliff.toml"
+  output-format:
+    description: "Output format: markdown or json"
+    required: false
+    default: "markdown"
+
+outputs:
+  changelog:
+    description: "Generated changelog content"
+    value: ${{ steps.generate.outputs.changelog }}
+  commits-analyzed:
+    description: "Number of commits analyzed"
+    value: ${{ steps.generate.outputs.commits_analyzed }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install git-cliff
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if command -v git-cliff &> /dev/null; then
+          echo "::notice::git-cliff already installed: $(git-cliff --version)"
+          exit 0
+        fi
+
+        echo "::group::Installing git-cliff"
+        # Try cargo install first
+        if command -v cargo &> /dev/null; then
+          cargo install git-cliff
+        else
+          # Fallback to binary release
+          CLIFF_VERSION="2.6.1"
+          case "$(uname -s)" in
+            Linux*)
+              curl -sSfL "https://github.com/orhun/git-cliff/releases/download/v${CLIFF_VERSION}/git-cliff-${CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz
+              sudo mv git-cliff-${CLIFF_VERSION}/git-cliff /usr/local/bin/
+              ;;
+            Darwin*)
+              curl -sSfL "https://github.com/orhun/git-cliff/releases/download/v${CLIFF_VERSION}/git-cliff-${CLIFF_VERSION}-x86_64-apple-darwin.tar.gz" | tar xz
+              sudo mv git-cliff-${CLIFF_VERSION}/git-cliff /usr/local/bin/
+              ;;
+            *)
+              echo "::error::Unsupported platform: $(uname -s)"
+              exit 1
+              ;;
+          esac
+        fi
+        echo "::endgroup::"
+
+        echo "::notice::Installed git-cliff: $(git-cliff --version)"
+
+    - name: Generate changelog
+      id: generate
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ARTIFACT="${{ inputs.artifact }}"
+        ARTIFACT_PATH="${{ inputs.artifact-path }}"
+        VERSION="${{ inputs.version }}"
+        BASE_REF="${{ inputs.base-ref }}"
+        CONFIG="${{ inputs.config }}"
+        OUTPUT_FORMAT="${{ inputs.output-format }}"
+
+        FULL_PATH="$ARTIFACT_PATH/$ARTIFACT"
+
+        echo "::group::Analyzing commits for $ARTIFACT"
+        echo "Path: $FULL_PATH"
+        echo "Version: $VERSION"
+        echo "Base ref: $BASE_REF"
+
+        # Ensure we have the base ref
+        git fetch origin --quiet 2>/dev/null || true
+
+        # Count commits affecting this artifact
+        COMMIT_COUNT=$(git log --oneline "$BASE_REF"..HEAD -- "$FULL_PATH" 2>/dev/null | wc -l | tr -d ' ')
+        echo "Commits affecting $ARTIFACT: $COMMIT_COUNT"
+        echo "commits_analyzed=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
+
+        if [[ "$COMMIT_COUNT" -eq 0 ]]; then
+          echo "::warning::No commits found for $ARTIFACT since $BASE_REF"
+          echo "changelog=" >> "$GITHUB_OUTPUT"
+          echo "::endgroup::"
+          exit 0
+        fi
+
+        # Check for git-cliff config
+        CLIFF_ARGS=""
+        if [[ -f "$CONFIG" ]]; then
+          CLIFF_ARGS="--config $CONFIG"
+          echo "Using config: $CONFIG"
+        else
+          echo "::notice::No git-cliff config found at $CONFIG, using defaults"
+        fi
+
+        # Generate changelog with git-cliff
+        CHANGELOG=""
+        if command -v git-cliff &> /dev/null; then
+          CHANGELOG=$(git-cliff \
+            $CLIFF_ARGS \
+            --include-path "$FULL_PATH/**" \
+            --unreleased \
+            --tag "$ARTIFACT-v$VERSION" \
+            --strip header \
+            --strip footer \
+            2>/dev/null || true)
+        fi
+
+        # Fallback if git-cliff fails or produces no output
+        if [[ -z "$CHANGELOG" || "$CHANGELOG" == *"No commits"* ]]; then
+          echo "::warning::git-cliff produced no output, generating simple changelog"
+
+          # Generate a simple changelog from commit messages
+          COMMITS=$(git log --oneline "$BASE_REF"..HEAD -- "$FULL_PATH" 2>/dev/null | head -50)
+
+          # Group commits by type
+          FEAT_COMMITS=""
+          FIX_COMMITS=""
+          OTHER_COMMITS=""
+
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            commit_msg="${line#* }"  # Remove commit hash
+
+            if [[ "$commit_msg" =~ ^feat ]]; then
+              FEAT_COMMITS+="- ${commit_msg#*: }"$'\n'
+            elif [[ "$commit_msg" =~ ^fix ]]; then
+              FIX_COMMITS+="- ${commit_msg#*: }"$'\n'
+            else
+              OTHER_COMMITS+="- $commit_msg"$'\n'
+            fi
+          done <<< "$COMMITS"
+
+          CHANGELOG="## [$VERSION] - $(date +%Y-%m-%d)"$'\n\n'
+
+          if [[ -n "$FEAT_COMMITS" ]]; then
+            CHANGELOG+="### Added"$'\n'"$FEAT_COMMITS"$'\n'
+          fi
+          if [[ -n "$FIX_COMMITS" ]]; then
+            CHANGELOG+="### Fixed"$'\n'"$FIX_COMMITS"$'\n'
+          fi
+          if [[ -n "$OTHER_COMMITS" ]]; then
+            CHANGELOG+="### Changed"$'\n'"$OTHER_COMMITS"$'\n'
+          fi
+        fi
+
+        echo "::endgroup::"
+
+        # Output format conversion
+        if [[ "$OUTPUT_FORMAT" == "json" ]]; then
+          # Convert markdown to JSON structure
+          CHANGELOG_JSON=$(echo "$CHANGELOG" | jq -Rs '.')
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG_JSON"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        else
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "::notice::Generated changelog for $ARTIFACT v$VERSION ($COMMIT_COUNT commits)"

--- a/actions/changelog/update/README.md
+++ b/actions/changelog/update/README.md
@@ -1,0 +1,230 @@
+# changelog/update
+
+Update CHANGELOG.md with a new version section following Keep-a-Changelog format.
+
+## Description
+
+This action updates a CHANGELOG.md file by inserting a new version section. It handles:
+
+- Creating the file if it doesn't exist
+- Inserting after `[Unreleased]` section if present
+- Inserting before existing version entries
+- Preventing duplicate version entries
+- Proper Keep-a-Changelog formatting
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `changelog-path` | Yes | - | Path to CHANGELOG.md file |
+| `version` | Yes | - | Version number for the new section |
+| `content` | Yes | - | Changelog content to insert (without version header) |
+| `date` | No | Today's date | Release date (YYYY-MM-DD format) |
+| `create-if-missing` | No | `true` | Create CHANGELOG.md if it does not exist |
+| `compare-url` | No | - | Comparison URL to include in version header |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `updated` | Whether the file was modified (`true`/`false`) |
+| `created` | Whether the file was created (`true`/`false`) |
+| `path` | Full path to the changelog file |
+
+## Usage Examples
+
+### Basic Usage
+
+```yaml
+- uses: arustydev/gha/actions/changelog/update@v1
+  with:
+    changelog-path: CHANGELOG.md
+    version: "1.3.0"
+    content: |
+      ### Added
+      - New feature X
+
+      ### Fixed
+      - Bug fix Y
+```
+
+### Combined with Generate Action
+
+```yaml
+- uses: arustydev/gha/actions/changelog/generate@v1
+  id: gen
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    version: "1.3.0"
+
+- uses: arustydev/gha/actions/changelog/update@v1
+  with:
+    changelog-path: charts/my-chart/CHANGELOG.md
+    version: "1.3.0"
+    content: ${{ steps.gen.outputs.changelog }}
+```
+
+### With Custom Date
+
+```yaml
+- uses: arustydev/gha/actions/changelog/update@v1
+  with:
+    changelog-path: CHANGELOG.md
+    version: "1.3.0"
+    date: "2024-01-15"
+    content: |
+      ### Added
+      - Feature released on specific date
+```
+
+### With Comparison URL
+
+```yaml
+- uses: arustydev/gha/actions/changelog/update@v1
+  with:
+    changelog-path: CHANGELOG.md
+    version: "1.3.0"
+    compare-url: "https://github.com/org/repo/compare/v1.2.0...v1.3.0"
+    content: |
+      ### Added
+      - New feature
+```
+
+This produces a header like:
+```markdown
+## [1.3.0](https://github.com/org/repo/compare/v1.2.0...v1.3.0) - 2024-01-15
+```
+
+### Complete Workflow Example
+
+```yaml
+name: Update Changelog
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(grep '^version:' charts/my-chart/Chart.yaml | awk '{print $2}')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: arustydev/gha/actions/changelog/generate@v1
+        id: changelog
+        with:
+          artifact: my-chart
+          artifact-path: charts
+          version: ${{ steps.version.outputs.version }}
+
+      - uses: arustydev/gha/actions/changelog/update@v1
+        id: update
+        with:
+          changelog-path: charts/my-chart/CHANGELOG.md
+          version: ${{ steps.version.outputs.version }}
+          content: ${{ steps.changelog.outputs.changelog }}
+
+      - name: Commit changes
+        if: steps.update.outputs.updated == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add charts/my-chart/CHANGELOG.md
+          git commit -m "docs(my-chart): update changelog for v${{ steps.version.outputs.version }}"
+          git push
+```
+
+### Handling New Charts
+
+```yaml
+- uses: arustydev/gha/actions/changelog/update@v1
+  with:
+    changelog-path: charts/new-chart/CHANGELOG.md
+    version: "0.1.0"
+    content: |
+      ### Added
+      - Initial release
+    create-if-missing: "true"  # Default, creates file if needed
+
+- name: Check if new file
+  run: |
+    if [[ "${{ steps.update.outputs.created }}" == "true" ]]; then
+      echo "Created new CHANGELOG.md"
+    fi
+```
+
+## Generated File Format
+
+When `create-if-missing` creates a new file, it follows this format:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2024-01-15
+
+### Added
+- Initial release
+```
+
+## Behavior with [Unreleased] Section
+
+If your changelog has an `[Unreleased]` section, the new version is inserted after it:
+
+**Before:**
+```markdown
+## [Unreleased]
+
+### Added
+- Pending feature
+
+## [1.2.0] - 2024-01-10
+...
+```
+
+**After running with version 1.3.0:**
+```markdown
+## [Unreleased]
+
+### Added
+- Pending feature
+
+## [1.3.0] - 2024-01-15
+
+### Added
+- New feature
+
+## [1.2.0] - 2024-01-10
+...
+```
+
+## Idempotency
+
+The action is idempotent - running it multiple times with the same version will:
+
+1. Detect the version already exists
+2. Skip the update
+3. Set `updated=false` in outputs
+4. Log a warning
+
+## Related Actions
+
+- [changelog/extract-version](../extract-version) - Extract changelog for a version
+- [changelog/generate](../generate) - Generate changelog from commits
+
+## License
+
+MIT

--- a/actions/changelog/update/action.yml
+++ b/actions/changelog/update/action.yml
@@ -1,0 +1,193 @@
+name: "Update CHANGELOG.md"
+description: "Update CHANGELOG.md with a new version section following Keep-a-Changelog format"
+author: "aRustyDev"
+
+branding:
+  icon: "edit-3"
+  color: "yellow"
+
+inputs:
+  changelog-path:
+    description: "Path to CHANGELOG.md file"
+    required: true
+  version:
+    description: "Version number for the new section"
+    required: true
+  content:
+    description: "Changelog content to insert (without version header)"
+    required: true
+  date:
+    description: "Release date (YYYY-MM-DD format, defaults to today)"
+    required: false
+    default: ""
+  create-if-missing:
+    description: "Create CHANGELOG.md if it does not exist"
+    required: false
+    default: "true"
+  compare-url:
+    description: "Comparison URL to include in version header"
+    required: false
+    default: ""
+
+outputs:
+  updated:
+    description: "Whether the file was modified (true/false)"
+    value: ${{ steps.update.outputs.updated }}
+  created:
+    description: "Whether the file was created (true/false)"
+    value: ${{ steps.update.outputs.created }}
+  path:
+    description: "Full path to the changelog file"
+    value: ${{ steps.update.outputs.path }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Update changelog
+      id: update
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        CHANGELOG_PATH="${{ inputs.changelog-path }}"
+        VERSION="${{ inputs.version }}"
+        CONTENT="${{ inputs.content }}"
+        DATE="${{ inputs.date }}"
+        CREATE_IF_MISSING="${{ inputs.create-if-missing }}"
+        COMPARE_URL="${{ inputs.compare-url }}"
+
+        # Default date to today if not provided
+        if [[ -z "$DATE" ]]; then
+          DATE=$(date +%Y-%m-%d)
+        fi
+
+        echo "path=$CHANGELOG_PATH" >> "$GITHUB_OUTPUT"
+
+        # Check if file exists
+        CREATED="false"
+        if [[ ! -f "$CHANGELOG_PATH" ]]; then
+          if [[ "$CREATE_IF_MISSING" == "true" ]]; then
+            echo "::notice::Creating new CHANGELOG.md at $CHANGELOG_PATH"
+
+            # Ensure directory exists
+            mkdir -p "$(dirname "$CHANGELOG_PATH")"
+
+            # Create new changelog with header
+            cat > "$CHANGELOG_PATH" << 'HEADER'
+        # Changelog
+
+        All notable changes to this project will be documented in this file.
+
+        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+        and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+        HEADER
+            CREATED="true"
+          else
+            echo "::error::Changelog file not found and create-if-missing is false: $CHANGELOG_PATH"
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+        fi
+
+        echo "created=$CREATED" >> "$GITHUB_OUTPUT"
+
+        # Build version header
+        VERSION_HEADER=""
+        if [[ -n "$COMPARE_URL" ]]; then
+          VERSION_HEADER="## [$VERSION]($COMPARE_URL) - $DATE"
+        else
+          VERSION_HEADER="## [$VERSION] - $DATE"
+        fi
+
+        # Check if version already exists
+        if grep -qE "^## \[$VERSION\]" "$CHANGELOG_PATH"; then
+          echo "::warning::Version $VERSION already exists in changelog, skipping"
+          echo "updated=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "::group::Updating changelog with version $VERSION"
+
+        # Create the new version entry
+        NEW_ENTRY="$VERSION_HEADER
+
+        $CONTENT
+        "
+
+        # Create temp file for the result
+        TEMP_FILE=$(mktemp)
+
+        # Strategy: Insert after header section, before any existing version entries
+        # Handle [Unreleased] section if present
+        awk -v entry="$NEW_ENTRY" '
+          BEGIN {
+            inserted = 0
+            in_header = 1
+            after_unreleased = 0
+          }
+
+          # Detect end of header section (first ## line)
+          /^## / {
+            in_header = 0
+
+            # If this is [Unreleased], mark it and continue
+            if (/^## \[Unreleased\]/) {
+              print
+              after_unreleased = 1
+              next
+            }
+
+            # If we were after [Unreleased], insert before this version
+            if (after_unreleased && !inserted) {
+              print entry
+              print ""
+              inserted = 1
+            }
+
+            # If no [Unreleased] and we hit a version, insert before it
+            if (!after_unreleased && !inserted) {
+              print entry
+              print ""
+              inserted = 1
+            }
+          }
+
+          { print }
+
+          # If we processed [Unreleased] and hit an empty line, check if next is a version
+          after_unreleased && /^$/ && !inserted {
+            # Peek ahead handled by main version detection
+          }
+
+          END {
+            # If we never inserted (no existing versions), add at end
+            if (!inserted) {
+              print ""
+              print entry
+            }
+          }
+        ' "$CHANGELOG_PATH" > "$TEMP_FILE"
+
+        mv "$TEMP_FILE" "$CHANGELOG_PATH"
+
+        echo "::notice::Updated $CHANGELOG_PATH with version $VERSION"
+        echo "::endgroup::"
+
+        echo "updated=true" >> "$GITHUB_OUTPUT"
+
+    - name: Show changelog diff
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        CHANGELOG_PATH="${{ inputs.changelog-path }}"
+
+        if git diff --quiet "$CHANGELOG_PATH" 2>/dev/null; then
+          echo "::notice::No changes to changelog"
+        else
+          echo "::group::Changelog diff"
+          git diff "$CHANGELOG_PATH" || true
+          echo "::endgroup::"
+        fi

--- a/actions/version-bump/calculate-version/README.md
+++ b/actions/version-bump/calculate-version/README.md
@@ -1,0 +1,169 @@
+# Calculate Version
+
+Calculate the next semantic version based on current version and bump type.
+
+This is a pure function that takes a version and bump type, and returns the incremented version following [SemVer](https://semver.org/) specification.
+
+## Usage
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/calculate-version@v1
+  id: version
+  with:
+    current-version: "1.2.3"
+    bump-type: minor
+
+- run: echo "Next version: ${{ steps.version.outputs.next-version }}"
+# Output: 1.3.0
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `current-version` | Yes | - | Current semver version (e.g., `1.2.3` or `v1.2.3`) |
+| `bump-type` | Yes | - | Bump type: `major`, `minor`, or `patch` |
+| `pre-release` | No | `""` | Pre-release identifier (e.g., `alpha`, `beta`, `rc`) |
+| `pre-release-bump` | No | `new` | How to handle pre-release: `increment`, `promote`, or `new` |
+| `build-metadata` | No | `""` | Build metadata to append after `+` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `next-version` | Calculated next version (without `v` prefix) |
+| `major` | Major version component |
+| `minor` | Minor version component |
+| `patch` | Patch version component |
+| `is-pre-release` | `true` if the version is a pre-release |
+| `pre-release-id` | Pre-release identifier (e.g., `alpha.1`) |
+
+## Version Bump Examples
+
+### Standard Bumps
+
+| Current | Bump Type | Result |
+|---------|-----------|--------|
+| `1.2.3` | `patch` | `1.2.4` |
+| `1.2.3` | `minor` | `1.3.0` |
+| `1.2.3` | `major` | `2.0.0` |
+| `0.1.0` | `major` | `1.0.0` |
+| `v1.2.3` | `patch` | `1.2.4` |
+
+### Pre-release Handling
+
+| Current | Bump | Pre-release | Pre-release Bump | Result |
+|---------|------|-------------|------------------|--------|
+| `1.2.3` | `minor` | `alpha` | `new` | `1.3.0-alpha.1` |
+| `1.3.0-alpha.1` | `minor` | `alpha` | `increment` | `1.3.0-alpha.2` |
+| `1.3.0-alpha.2` | `minor` | `beta` | `new` | `1.3.0-beta.1` |
+| `1.3.0-beta.1` | `minor` | - | `promote` | `1.3.0` |
+
+### Build Metadata
+
+| Current | Bump | Build Metadata | Result |
+|---------|------|----------------|--------|
+| `1.2.3` | `patch` | `build.456` | `1.2.4+build.456` |
+| `1.2.3+build.123` | `patch` | `build.456` | `1.2.4+build.456` |
+
+## Examples
+
+### Basic Usage
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/calculate-version@v1
+  id: version
+  with:
+    current-version: "1.2.3"
+    bump-type: minor
+
+- run: |
+    echo "Next: ${{ steps.version.outputs.next-version }}"
+    echo "Major: ${{ steps.version.outputs.major }}"
+    echo "Minor: ${{ steps.version.outputs.minor }}"
+    echo "Patch: ${{ steps.version.outputs.patch }}"
+```
+
+### Pre-release Versions
+
+```yaml
+# Start alpha pre-release
+- uses: arustydev/gha/actions/version-bump/calculate-version@v1
+  id: alpha
+  with:
+    current-version: "1.2.3"
+    bump-type: minor
+    pre-release: alpha
+
+- run: echo "${{ steps.alpha.outputs.next-version }}"
+# Output: 1.3.0-alpha.1
+
+# Increment alpha
+- uses: arustydev/gha/actions/version-bump/calculate-version@v1
+  id: alpha2
+  with:
+    current-version: "1.3.0-alpha.1"
+    bump-type: minor
+    pre-release: alpha
+    pre-release-bump: increment
+
+- run: echo "${{ steps.alpha2.outputs.next-version }}"
+# Output: 1.3.0-alpha.2
+
+# Promote to stable
+- uses: arustydev/gha/actions/version-bump/calculate-version@v1
+  id: stable
+  with:
+    current-version: "1.3.0-alpha.2"
+    bump-type: minor
+    pre-release-bump: promote
+
+- run: echo "${{ steps.stable.outputs.next-version }}"
+# Output: 1.3.0
+```
+
+### With Build Metadata
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/calculate-version@v1
+  id: version
+  with:
+    current-version: "1.2.3"
+    bump-type: patch
+    build-metadata: "build.${{ github.run_number }}"
+
+- run: echo "${{ steps.version.outputs.next-version }}"
+# Output: 1.2.4+build.123
+```
+
+### Complete Pipeline with determine-bump
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/determine-bump@v1
+  id: bump
+  with:
+    artifact: my-chart
+    artifact-path: charts
+
+- name: Get current version
+  id: current
+  run: |
+    VERSION=$(grep '^version:' charts/my-chart/Chart.yaml | awk '{print $2}')
+    echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+- uses: arustydev/gha/actions/version-bump/calculate-version@v1
+  id: next
+  with:
+    current-version: ${{ steps.current.outputs.version }}
+    bump-type: ${{ steps.bump.outputs.bump-type }}
+
+- uses: arustydev/gha/actions/version-bump/update-manifest@v1
+  with:
+    manifest-path: charts/my-chart/Chart.yaml
+    new-version: ${{ steps.next.outputs.next-version }}
+```
+
+## Related Actions
+
+- [determine-bump](../determine-bump/) - Analyze commits to determine bump type
+- [update-manifest](../update-manifest/) - Update version in manifest files

--- a/actions/version-bump/calculate-version/action.yml
+++ b/actions/version-bump/calculate-version/action.yml
@@ -1,0 +1,195 @@
+name: "Calculate Version"
+description: "Calculate the next semantic version based on current version and bump type"
+author: "aRustyDev"
+
+branding:
+  icon: "hash"
+  color: "green"
+
+inputs:
+  current-version:
+    description: "Current semver version (e.g., '1.2.3' or 'v1.2.3')"
+    required: true
+  bump-type:
+    description: "Bump type: 'major', 'minor', or 'patch'"
+    required: true
+  pre-release:
+    description: "Pre-release identifier (e.g., 'alpha', 'beta', 'rc'). Leave empty for stable releases."
+    required: false
+    default: ""
+  pre-release-bump:
+    description: "How to handle pre-release versions: 'increment' (bump pre-release number), 'promote' (remove pre-release), 'new' (start new pre-release)"
+    required: false
+    default: "new"
+  build-metadata:
+    description: "Build metadata to append (e.g., 'build.123'). Will be appended after '+'"
+    required: false
+    default: ""
+
+outputs:
+  next-version:
+    description: "Calculated next version (without 'v' prefix)"
+    value: ${{ steps.calculate.outputs.next-version }}
+  major:
+    description: "Major version component"
+    value: ${{ steps.calculate.outputs.major }}
+  minor:
+    description: "Minor version component"
+    value: ${{ steps.calculate.outputs.minor }}
+  patch:
+    description: "Patch version component"
+    value: ${{ steps.calculate.outputs.patch }}
+  is-pre-release:
+    description: "'true' if the version is a pre-release"
+    value: ${{ steps.calculate.outputs.is-pre-release }}
+  pre-release-id:
+    description: "Pre-release identifier (e.g., 'alpha.1')"
+    value: ${{ steps.calculate.outputs.pre-release-id }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Calculate Next Version
+      id: calculate
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        CURRENT_VERSION="${{ inputs.current-version }}"
+        BUMP_TYPE="${{ inputs.bump-type }}"
+        PRE_RELEASE="${{ inputs.pre-release }}"
+        PRE_RELEASE_BUMP="${{ inputs.pre-release-bump }}"
+        BUILD_METADATA="${{ inputs.build-metadata }}"
+
+        echo "::group::Calculating next version"
+        echo "Current version: $CURRENT_VERSION"
+        echo "Bump type: $BUMP_TYPE"
+        echo "Pre-release: $PRE_RELEASE"
+        echo "Pre-release bump: $PRE_RELEASE_BUMP"
+        echo "Build metadata: $BUILD_METADATA"
+
+        # Validate bump type
+        case "$BUMP_TYPE" in
+          major|minor|patch)
+            ;;
+          *)
+            echo "::error::Invalid bump type: $BUMP_TYPE. Must be 'major', 'minor', or 'patch'."
+            exit 1
+            ;;
+        esac
+
+        # Remove leading 'v' if present
+        CURRENT_VERSION="${CURRENT_VERSION#v}"
+
+        # Remove build metadata (everything after +)
+        CURRENT_VERSION="${CURRENT_VERSION%%+*}"
+
+        # Extract pre-release suffix and base version
+        CURRENT_PRE_RELEASE=""
+        BASE_VERSION="$CURRENT_VERSION"
+        if [[ "$CURRENT_VERSION" == *-* ]]; then
+          BASE_VERSION="${CURRENT_VERSION%%-*}"
+          CURRENT_PRE_RELEASE="${CURRENT_VERSION#*-}"
+        fi
+
+        # Parse base version components
+        if ! [[ "$BASE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+          echo "::error::Invalid version format: $BASE_VERSION. Expected X.Y.Z"
+          exit 1
+        fi
+
+        MAJOR="${BASH_REMATCH[1]}"
+        MINOR="${BASH_REMATCH[2]}"
+        PATCH="${BASH_REMATCH[3]}"
+
+        echo "Parsed: major=$MAJOR, minor=$MINOR, patch=$PATCH, pre-release=$CURRENT_PRE_RELEASE"
+
+        # Handle pre-release version bumping
+        NEW_PRE_RELEASE=""
+        IS_PRE_RELEASE="false"
+
+        if [[ -n "$CURRENT_PRE_RELEASE" && "$PRE_RELEASE_BUMP" == "increment" && -n "$PRE_RELEASE" ]]; then
+          # Increment existing pre-release
+          # Extract the numeric part from current pre-release
+          if [[ "$CURRENT_PRE_RELEASE" =~ ^([a-z]+)\.([0-9]+)$ ]]; then
+            CURRENT_PRE_ID="${BASH_REMATCH[1]}"
+            CURRENT_PRE_NUM="${BASH_REMATCH[2]}"
+            if [[ "$CURRENT_PRE_ID" == "$PRE_RELEASE" ]]; then
+              NEW_PRE_RELEASE="$PRE_RELEASE.$((CURRENT_PRE_NUM + 1))"
+              IS_PRE_RELEASE="true"
+              echo "Incrementing pre-release: $CURRENT_PRE_RELEASE -> $NEW_PRE_RELEASE"
+            else
+              # Different pre-release type, start new
+              NEW_PRE_RELEASE="$PRE_RELEASE.1"
+              IS_PRE_RELEASE="true"
+              echo "New pre-release type: $NEW_PRE_RELEASE"
+            fi
+          else
+            # Can't parse, start new
+            NEW_PRE_RELEASE="$PRE_RELEASE.1"
+            IS_PRE_RELEASE="true"
+          fi
+        elif [[ -n "$CURRENT_PRE_RELEASE" && "$PRE_RELEASE_BUMP" == "promote" ]]; then
+          # Promote to stable - no version bump needed, just remove pre-release
+          NEW_PRE_RELEASE=""
+          IS_PRE_RELEASE="false"
+          echo "Promoting to stable release"
+        elif [[ -n "$PRE_RELEASE" ]]; then
+          # Start new pre-release or apply pre-release to bumped version
+          # First, bump the version
+          case "$BUMP_TYPE" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          NEW_PRE_RELEASE="$PRE_RELEASE.1"
+          IS_PRE_RELEASE="true"
+          echo "Starting new pre-release: $NEW_PRE_RELEASE"
+        else
+          # Standard bump - no pre-release
+          case "$BUMP_TYPE" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          echo "Standard bump: $BUMP_TYPE"
+        fi
+
+        # Construct next version
+        NEXT_VERSION="$MAJOR.$MINOR.$PATCH"
+        if [[ -n "$NEW_PRE_RELEASE" ]]; then
+          NEXT_VERSION="$NEXT_VERSION-$NEW_PRE_RELEASE"
+        fi
+        if [[ -n "$BUILD_METADATA" ]]; then
+          NEXT_VERSION="$NEXT_VERSION+$BUILD_METADATA"
+        fi
+
+        echo "::endgroup::"
+
+        # Set outputs
+        echo "next-version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+        echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+        echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+        echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
+        echo "is-pre-release=$IS_PRE_RELEASE" >> "$GITHUB_OUTPUT"
+        echo "pre-release-id=$NEW_PRE_RELEASE" >> "$GITHUB_OUTPUT"
+
+        echo "::notice::Calculated next version: $NEXT_VERSION (from $CURRENT_VERSION via $BUMP_TYPE bump)"

--- a/actions/version-bump/determine-bump/README.md
+++ b/actions/version-bump/determine-bump/README.md
@@ -1,0 +1,170 @@
+# Determine Version Bump
+
+Analyze conventional commits to determine the appropriate semantic version bump type.
+
+This action examines commit messages in a range to determine whether the change requires a major (breaking), minor (feature), or patch (fix) bump based on [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Usage
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/determine-bump@v1
+  id: bump
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    base-ref: origin/main
+
+- run: echo "Bump type: ${{ steps.bump.outputs.bump-type }}"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `artifact` | Yes | - | Artifact name to analyze (e.g., chart name, package name) |
+| `artifact-path` | Yes | - | Path to artifacts directory (e.g., `charts`, `packages`) |
+| `base-ref` | No | `origin/main` | Base ref for commit comparison |
+| `type-mapping` | No | See below | JSON mapping of commit types to bump levels |
+| `scopes` | No | `""` | Comma-separated list of scopes to filter commits |
+
+### Default Type Mapping
+
+```json
+{
+  "feat": "minor",
+  "fix": "patch",
+  "perf": "patch",
+  "refactor": "patch",
+  "docs": "patch",
+  "style": "patch",
+  "test": "patch",
+  "build": "patch",
+  "ci": "patch",
+  "chore": "patch"
+}
+```
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `bump-type` | Determined bump type: `major`, `minor`, or `patch` |
+| `has-breaking` | `true` if breaking changes were detected |
+| `has-features` | `true` if new features were detected |
+| `commit-count` | Number of commits analyzed |
+| `commits-json` | JSON array of analyzed commits with type and message |
+
+## Bump Type Detection
+
+The action determines bump type using the following rules (in order of priority):
+
+### Major (Breaking Change)
+
+A **major** bump is triggered when:
+- A commit contains `!` before the colon: `feat!: breaking change` or `fix(scope)!: breaking`
+- A commit contains `BREAKING CHANGE` or `BREAKING-CHANGE` anywhere in the message
+
+### Minor (New Feature)
+
+A **minor** bump is triggered when:
+- A commit uses the `feat` type: `feat: add new capability`
+- A commit type maps to `minor` in the type-mapping
+
+### Patch (Bug Fix / Other)
+
+A **patch** bump is used for:
+- `fix`, `perf`, `refactor`, `docs`, `style`, `test`, `build`, `ci`, `chore` commits
+- Any unrecognized commit type
+- When no commits are found
+
+## Examples
+
+### Basic Usage
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/determine-bump@v1
+  id: bump
+  with:
+    artifact: cloudflared
+    artifact-path: charts
+
+- name: Show Results
+  run: |
+    echo "Bump type: ${{ steps.bump.outputs.bump-type }}"
+    echo "Has breaking: ${{ steps.bump.outputs.has-breaking }}"
+    echo "Commit count: ${{ steps.bump.outputs.commit-count }}"
+```
+
+### Custom Type Mapping
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/determine-bump@v1
+  id: bump
+  with:
+    artifact: my-lib
+    artifact-path: packages
+    type-mapping: |
+      {
+        "feat": "minor",
+        "fix": "patch",
+        "perf": "minor",
+        "refactor": "patch"
+      }
+```
+
+### Using with calculate-version
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/determine-bump@v1
+  id: bump
+  with:
+    artifact: my-chart
+    artifact-path: charts
+
+- uses: arustydev/gha/actions/version-bump/calculate-version@v1
+  id: version
+  with:
+    current-version: "1.2.3"
+    bump-type: ${{ steps.bump.outputs.bump-type }}
+
+- run: echo "Next version: ${{ steps.version.outputs.next-version }}"
+```
+
+### With Different Base Ref
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/determine-bump@v1
+  id: bump
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    base-ref: origin/integration
+```
+
+## Commits JSON Output
+
+The `commits-json` output provides detailed information about each commit:
+
+```json
+[
+  {
+    "hash": "abc1234",
+    "message": "feat(auth): add OAuth2 support",
+    "type": "feat",
+    "scope": "auth",
+    "breaking": false
+  },
+  {
+    "hash": "def5678",
+    "message": "fix!: resolve critical bug",
+    "type": "fix",
+    "scope": "",
+    "breaking": true
+  }
+]
+```
+
+## Related Actions
+
+- [calculate-version](../calculate-version/) - Calculate next semver from current version and bump type
+- [update-manifest](../update-manifest/) - Update version in manifest files

--- a/actions/version-bump/determine-bump/action.yml
+++ b/actions/version-bump/determine-bump/action.yml
@@ -1,0 +1,188 @@
+name: "Determine Version Bump"
+description: "Analyze conventional commits to determine the appropriate semver bump type"
+author: "aRustyDev"
+
+branding:
+  icon: "git-commit"
+  color: "blue"
+
+inputs:
+  artifact:
+    description: "Artifact name to analyze (e.g., chart name, package name)"
+    required: true
+  artifact-path:
+    description: "Path to artifacts directory (e.g., 'charts', 'packages')"
+    required: true
+  base-ref:
+    description: "Base ref for commit comparison"
+    required: false
+    default: "origin/main"
+  type-mapping:
+    description: |
+      JSON mapping of commit types to bump levels.
+      Default: {"feat": "minor", "fix": "patch", "perf": "patch", "refactor": "patch", "docs": "patch", "style": "patch", "test": "patch", "build": "patch", "ci": "patch", "chore": "patch"}
+    required: false
+    default: '{"feat": "minor", "fix": "patch", "perf": "patch", "refactor": "patch", "docs": "patch", "style": "patch", "test": "patch", "build": "patch", "ci": "patch", "chore": "patch"}'
+  scopes:
+    description: "Comma-separated list of scopes to filter commits (empty = all scopes)"
+    required: false
+    default: ""
+
+outputs:
+  bump-type:
+    description: "Determined bump type: 'major', 'minor', or 'patch'"
+    value: ${{ steps.analyze.outputs.bump-type }}
+  has-breaking:
+    description: "'true' if breaking changes were detected"
+    value: ${{ steps.analyze.outputs.has-breaking }}
+  has-features:
+    description: "'true' if new features were detected"
+    value: ${{ steps.analyze.outputs.has-features }}
+  commit-count:
+    description: "Number of commits analyzed"
+    value: ${{ steps.analyze.outputs.commit-count }}
+  commits-json:
+    description: "JSON array of analyzed commits with type and message"
+    value: ${{ steps.analyze.outputs.commits-json }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Analyze Commits
+      id: analyze
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ARTIFACT="${{ inputs.artifact }}"
+        ARTIFACT_PATH="${{ inputs.artifact-path }}"
+        BASE_REF="${{ inputs.base-ref }}"
+        TYPE_MAPPING='${{ inputs.type-mapping }}'
+        SCOPES="${{ inputs.scopes }}"
+
+        echo "::group::Analyzing commits for $ARTIFACT"
+        echo "Artifact: $ARTIFACT"
+        echo "Artifact path: $ARTIFACT_PATH"
+        echo "Base ref: $BASE_REF"
+
+        # Build the path to analyze
+        FULL_PATH="$ARTIFACT_PATH/$ARTIFACT"
+
+        # Get commits affecting this artifact since base
+        if ! COMMITS=$(git log --oneline "$BASE_REF"..HEAD -- "$FULL_PATH" 2>/dev/null); then
+          echo "::warning::Failed to get commits, using patch bump"
+          COMMITS=""
+        fi
+
+        COMMIT_COUNT=$(echo "$COMMITS" | grep -c . || echo 0)
+        echo "Found $COMMIT_COUNT commits affecting $FULL_PATH"
+
+        # Initialize flags
+        HAS_BREAKING="false"
+        HAS_FEATURES="false"
+        BUMP_TYPE="patch"
+
+        # Build JSON array of commits
+        COMMITS_JSON="[]"
+        if [[ -n "$COMMITS" ]]; then
+          while IFS= read -r commit_line; do
+            if [[ -z "$commit_line" ]]; then
+              continue
+            fi
+
+            # Extract hash and message
+            HASH=$(echo "$commit_line" | cut -d' ' -f1)
+            MESSAGE=$(echo "$commit_line" | cut -d' ' -f2-)
+
+            # Extract type from conventional commit
+            TYPE=""
+            SCOPE=""
+            BREAKING=""
+
+            if [[ "$MESSAGE" =~ ^([a-z]+)(\(([^)]+)\))?(!)?:\ (.+)$ ]]; then
+              TYPE="${BASH_REMATCH[1]}"
+              SCOPE="${BASH_REMATCH[3]:-}"
+              BREAKING="${BASH_REMATCH[4]:-}"
+            fi
+
+            # Add to JSON array
+            COMMIT_OBJ=$(jq -n \
+              --arg hash "$HASH" \
+              --arg message "$MESSAGE" \
+              --arg type "$TYPE" \
+              --arg scope "$SCOPE" \
+              --arg breaking "$BREAKING" \
+              '{hash: $hash, message: $message, type: $type, scope: $scope, breaking: ($breaking != "")}'
+            )
+            COMMITS_JSON=$(echo "$COMMITS_JSON" | jq --argjson obj "$COMMIT_OBJ" '. + [$obj]')
+          done <<< "$COMMITS"
+        fi
+
+        # Check for breaking changes (major bump)
+        # Pattern 1: "!" before colon (e.g., "feat!:" or "fix(scope)!:")
+        # Pattern 2: "BREAKING CHANGE" or "BREAKING-CHANGE" in body/footer
+        if echo "$COMMITS" | grep -qiE '(BREAKING[ -]CHANGE|!:)'; then
+          HAS_BREAKING="true"
+          BUMP_TYPE="major"
+          echo "::notice::Breaking change detected - major bump required"
+        fi
+
+        # Check for features (minor bump) if not already major
+        if [[ "$BUMP_TYPE" != "major" ]]; then
+          if echo "$COMMITS" | grep -qE '^[a-f0-9]+ feat'; then
+            HAS_FEATURES="true"
+            BUMP_TYPE="minor"
+            echo "::notice::New feature detected - minor bump required"
+          fi
+        fi
+
+        # If still patch, check for any recognized type
+        if [[ "$BUMP_TYPE" == "patch" && -n "$COMMITS" ]]; then
+          # Parse type mapping to find highest bump level
+          HIGHEST_BUMP="patch"
+          while IFS= read -r commit_line; do
+            if [[ -z "$commit_line" ]]; then
+              continue
+            fi
+            MESSAGE=$(echo "$commit_line" | cut -d' ' -f2-)
+
+            # Extract type
+            if [[ "$MESSAGE" =~ ^([a-z]+)(\([^)]+\))?!?:\ .+$ ]]; then
+              COMMIT_TYPE="${BASH_REMATCH[1]}"
+
+              # Look up bump level for this type
+              LEVEL=$(echo "$TYPE_MAPPING" | jq -r --arg type "$COMMIT_TYPE" '.[$type] // "patch"')
+
+              # Update highest bump if needed
+              if [[ "$LEVEL" == "minor" && "$HIGHEST_BUMP" == "patch" ]]; then
+                HIGHEST_BUMP="minor"
+              elif [[ "$LEVEL" == "major" ]]; then
+                HIGHEST_BUMP="major"
+              fi
+            fi
+          done <<< "$COMMITS"
+          BUMP_TYPE="$HIGHEST_BUMP"
+        fi
+
+        # Default to patch if no commits
+        if [[ -z "$COMMITS" ]]; then
+          echo "::notice::No commits found - defaulting to patch bump"
+          BUMP_TYPE="patch"
+        fi
+
+        echo "::endgroup::"
+
+        # Set outputs
+        echo "bump-type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
+        echo "has-breaking=$HAS_BREAKING" >> "$GITHUB_OUTPUT"
+        echo "has-features=$HAS_FEATURES" >> "$GITHUB_OUTPUT"
+        echo "commit-count=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
+
+        # Handle multi-line JSON output
+        {
+          echo "commits-json<<EOF"
+          echo "$COMMITS_JSON"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "::notice::Determined bump type: $BUMP_TYPE (commits: $COMMIT_COUNT, breaking: $HAS_BREAKING, features: $HAS_FEATURES)"

--- a/actions/version-bump/update-manifest/README.md
+++ b/actions/version-bump/update-manifest/README.md
@@ -1,0 +1,227 @@
+# Update Manifest Version
+
+Update the version in a manifest file supporting multiple formats (YAML, TOML, JSON).
+
+This action modifies version fields in manifest files while preserving file formatting as much as possible.
+
+## Usage
+
+```yaml
+# Helm Chart
+- uses: arustydev/gha/actions/version-bump/update-manifest@v1
+  with:
+    manifest-path: charts/my-chart/Chart.yaml
+    new-version: "1.3.0"
+
+# Cargo.toml
+- uses: arustydev/gha/actions/version-bump/update-manifest@v1
+  with:
+    manifest-path: Cargo.toml
+    new-version: "1.3.0"
+    format: toml
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `manifest-path` | Yes | - | Path to the manifest file |
+| `new-version` | Yes | - | New version to set |
+| `version-key` | No | `version` | Key name for version in manifest |
+| `format` | No | `auto` | File format: `yaml`, `toml`, `json`, or `auto` |
+| `app-version` | No | `""` | Application version (for Helm charts, sets `appVersion`) |
+| `app-version-key` | No | `appVersion` | Key name for application version |
+| `update-lockfile` | No | `false` | Update associated lockfile if present |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `updated` | `true` if the file was modified |
+| `previous-version` | Version before update |
+| `lockfile-updated` | `true` if a lockfile was also updated |
+
+## Supported Formats
+
+### YAML (`.yaml`, `.yml`)
+
+Handles both quoted and unquoted values:
+
+```yaml
+version: 1.2.3
+# or
+version: "1.2.3"
+```
+
+Uses `sed` for modification to preserve formatting (comments, spacing, etc.).
+
+### TOML (`.toml`)
+
+```toml
+version = "1.2.3"
+# or
+[package]
+version = "1.2.3"
+```
+
+### JSON (`.json`)
+
+```json
+{
+  "version": "1.2.3"
+}
+```
+
+Uses `jq` for modification, ensuring valid JSON output.
+
+## Format Auto-Detection
+
+When `format` is set to `auto` (default), the format is detected from the file extension:
+
+| Extension | Format |
+|-----------|--------|
+| `.yaml`, `.yml` | yaml |
+| `.toml` | toml |
+| `.json` | json |
+
+## Examples
+
+### Helm Chart with appVersion
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/update-manifest@v1
+  with:
+    manifest-path: charts/my-chart/Chart.yaml
+    new-version: "1.3.0"
+    app-version: "2.0.0"
+```
+
+**Before:**
+```yaml
+version: 1.2.3
+appVersion: "1.9.0"
+```
+
+**After:**
+```yaml
+version: 1.3.0
+appVersion: "2.0.0"
+```
+
+### Cargo.toml with Lockfile Update
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/update-manifest@v1
+  with:
+    manifest-path: Cargo.toml
+    new-version: "1.3.0"
+    update-lockfile: "true"
+```
+
+This will update both `Cargo.toml` and regenerate `Cargo.lock`.
+
+### package.json
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/update-manifest@v1
+  with:
+    manifest-path: package.json
+    new-version: "1.3.0"
+    format: json
+    update-lockfile: "true"
+```
+
+### Custom Version Key
+
+```yaml
+# For a manifest with non-standard key
+- uses: arustydev/gha/actions/version-bump/update-manifest@v1
+  with:
+    manifest-path: config.yaml
+    new-version: "1.3.0"
+    version-key: "chart_version"
+```
+
+### Complete Version Bump Pipeline
+
+```yaml
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: arustydev/gha/actions/version-bump/determine-bump@v1
+        id: bump
+        with:
+          artifact: my-chart
+          artifact-path: charts
+
+      - name: Get current version
+        id: current
+        run: |
+          VERSION=$(grep '^version:' charts/my-chart/Chart.yaml | awk '{print $2}')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: arustydev/gha/actions/version-bump/calculate-version@v1
+        id: next
+        with:
+          current-version: ${{ steps.current.outputs.version }}
+          bump-type: ${{ steps.bump.outputs.bump-type }}
+
+      - uses: arustydev/gha/actions/version-bump/update-manifest@v1
+        id: update
+        with:
+          manifest-path: charts/my-chart/Chart.yaml
+          new-version: ${{ steps.next.outputs.next-version }}
+
+      - name: Commit changes
+        if: steps.update.outputs.updated == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add charts/my-chart/Chart.yaml
+          git commit -m "chore(my-chart): bump version to ${{ steps.next.outputs.next-version }}"
+```
+
+### Conditional Update
+
+```yaml
+- uses: arustydev/gha/actions/version-bump/update-manifest@v1
+  id: update
+  with:
+    manifest-path: Chart.yaml
+    new-version: "1.3.0"
+
+- name: Report
+  run: |
+    if [[ "${{ steps.update.outputs.updated }}" == "true" ]]; then
+      echo "Version updated from ${{ steps.update.outputs.previous-version }} to 1.3.0"
+    else
+      echo "Version was already 1.3.0"
+    fi
+```
+
+## Lockfile Support
+
+When `update-lockfile: true`, the action attempts to update the corresponding lockfile:
+
+| Manifest | Lockfile | Method |
+|----------|----------|--------|
+| `Cargo.toml` | `Cargo.lock` | `cargo update --offline` or `cargo generate-lockfile` |
+| `package.json` | `package-lock.json` | `npm install --package-lock-only` |
+| `pyproject.toml` | `poetry.lock` | `poetry lock --no-update` |
+
+Note: Lockfile updates require the corresponding toolchain to be installed.
+
+## Idempotency
+
+The action is idempotent. If the version is already set to the target value:
+- `updated` output will be `false`
+- The file will not be modified
+- No error will be raised
+
+## Related Actions
+
+- [determine-bump](../determine-bump/) - Analyze commits to determine bump type
+- [calculate-version](../calculate-version/) - Calculate next semver from current version

--- a/actions/version-bump/update-manifest/action.yml
+++ b/actions/version-bump/update-manifest/action.yml
@@ -1,0 +1,218 @@
+name: "Update Manifest Version"
+description: "Update the version in a manifest file (YAML, TOML, or JSON)"
+author: "aRustyDev"
+
+branding:
+  icon: "edit-3"
+  color: "orange"
+
+inputs:
+  manifest-path:
+    description: "Path to the manifest file"
+    required: true
+  new-version:
+    description: "New version to set"
+    required: true
+  version-key:
+    description: "Key name for version in manifest"
+    required: false
+    default: "version"
+  format:
+    description: "File format: 'yaml', 'toml', 'json', or 'auto' (detect from extension)"
+    required: false
+    default: "auto"
+  app-version:
+    description: "Application version to set (for Helm charts, sets appVersion)"
+    required: false
+    default: ""
+  app-version-key:
+    description: "Key name for application version"
+    required: false
+    default: "appVersion"
+  update-lockfile:
+    description: "Update associated lockfile if present (e.g., Cargo.lock, package-lock.json)"
+    required: false
+    default: "false"
+
+outputs:
+  updated:
+    description: "'true' if the file was modified"
+    value: ${{ steps.update.outputs.updated }}
+  previous-version:
+    description: "Version before update"
+    value: ${{ steps.update.outputs.previous-version }}
+  lockfile-updated:
+    description: "'true' if a lockfile was also updated"
+    value: ${{ steps.update.outputs.lockfile-updated }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Update Manifest
+      id: update
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        MANIFEST_PATH="${{ inputs.manifest-path }}"
+        NEW_VERSION="${{ inputs.new-version }}"
+        VERSION_KEY="${{ inputs.version-key }}"
+        FORMAT="${{ inputs.format }}"
+        APP_VERSION="${{ inputs.app-version }}"
+        APP_VERSION_KEY="${{ inputs.app-version-key }}"
+        UPDATE_LOCKFILE="${{ inputs.update-lockfile }}"
+
+        echo "::group::Updating manifest version"
+        echo "Manifest: $MANIFEST_PATH"
+        echo "New version: $NEW_VERSION"
+        echo "Version key: $VERSION_KEY"
+        echo "Format: $FORMAT"
+
+        # Validate manifest exists
+        if [[ ! -f "$MANIFEST_PATH" ]]; then
+          echo "::error::Manifest file not found: $MANIFEST_PATH"
+          exit 1
+        fi
+
+        # Auto-detect format from extension
+        if [[ "$FORMAT" == "auto" ]]; then
+          case "$MANIFEST_PATH" in
+            *.yaml|*.yml)
+              FORMAT="yaml"
+              ;;
+            *.toml)
+              FORMAT="toml"
+              ;;
+            *.json)
+              FORMAT="json"
+              ;;
+            *)
+              echo "::error::Cannot auto-detect format for: $MANIFEST_PATH"
+              exit 1
+              ;;
+          esac
+          echo "Auto-detected format: $FORMAT"
+        fi
+
+        # Get previous version
+        PREVIOUS_VERSION=""
+        case "$FORMAT" in
+          yaml)
+            # Use grep/awk for robustness (yq can change formatting)
+            PREVIOUS_VERSION=$(grep "^${VERSION_KEY}:" "$MANIFEST_PATH" | head -1 | awk '{print $2}' | tr -d '"' | tr -d "'")
+            ;;
+          toml)
+            # Handle both [package] section and root level
+            PREVIOUS_VERSION=$(grep "^${VERSION_KEY}[[:space:]]*=" "$MANIFEST_PATH" | head -1 | sed 's/.*=[[:space:]]*"\?\([^"]*\)"\?.*/\1/')
+            ;;
+          json)
+            PREVIOUS_VERSION=$(jq -r ".${VERSION_KEY} // empty" "$MANIFEST_PATH")
+            ;;
+        esac
+
+        if [[ -z "$PREVIOUS_VERSION" ]]; then
+          echo "::warning::Could not find previous version in $MANIFEST_PATH"
+          PREVIOUS_VERSION="unknown"
+        fi
+
+        echo "Previous version: $PREVIOUS_VERSION"
+
+        # Check if update is needed
+        if [[ "$PREVIOUS_VERSION" == "$NEW_VERSION" ]]; then
+          echo "::notice::Version already set to $NEW_VERSION, no update needed"
+          echo "updated=false" >> "$GITHUB_OUTPUT"
+          echo "previous-version=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
+          echo "lockfile-updated=false" >> "$GITHUB_OUTPUT"
+          echo "::endgroup::"
+          exit 0
+        fi
+
+        # Update version based on format
+        UPDATED="false"
+        case "$FORMAT" in
+          yaml)
+            # Use sed for YAML to preserve formatting
+            # Handle both quoted and unquoted values
+            if grep -q "^${VERSION_KEY}:[[:space:]]*['\"]" "$MANIFEST_PATH"; then
+              # Quoted value
+              sed -i.bak "s/^${VERSION_KEY}:[[:space:]]*['\"][^'\"]*['\"]/${VERSION_KEY}: \"${NEW_VERSION}\"/" "$MANIFEST_PATH"
+            else
+              # Unquoted value
+              sed -i.bak "s/^${VERSION_KEY}:[[:space:]]*.*$/${VERSION_KEY}: ${NEW_VERSION}/" "$MANIFEST_PATH"
+            fi
+            rm -f "${MANIFEST_PATH}.bak"
+            UPDATED="true"
+
+            # Handle appVersion for Helm charts
+            if [[ -n "$APP_VERSION" ]]; then
+              if grep -q "^${APP_VERSION_KEY}:" "$MANIFEST_PATH"; then
+                if grep -q "^${APP_VERSION_KEY}:[[:space:]]*['\"]" "$MANIFEST_PATH"; then
+                  sed -i.bak "s/^${APP_VERSION_KEY}:[[:space:]]*['\"][^'\"]*['\"]/${APP_VERSION_KEY}: \"${APP_VERSION}\"/" "$MANIFEST_PATH"
+                else
+                  sed -i.bak "s/^${APP_VERSION_KEY}:[[:space:]]*.*$/${APP_VERSION_KEY}: ${APP_VERSION}/" "$MANIFEST_PATH"
+                fi
+                rm -f "${MANIFEST_PATH}.bak"
+                echo "::notice::Updated $APP_VERSION_KEY to $APP_VERSION"
+              fi
+            fi
+            ;;
+
+          toml)
+            # Use sed for TOML
+            sed -i.bak "s/^${VERSION_KEY}[[:space:]]*=.*/${VERSION_KEY} = \"${NEW_VERSION}\"/" "$MANIFEST_PATH"
+            rm -f "${MANIFEST_PATH}.bak"
+            UPDATED="true"
+            ;;
+
+          json)
+            # Use jq for JSON
+            TEMP_FILE=$(mktemp)
+            jq ".${VERSION_KEY} = \"${NEW_VERSION}\"" "$MANIFEST_PATH" > "$TEMP_FILE"
+            mv "$TEMP_FILE" "$MANIFEST_PATH"
+            UPDATED="true"
+            ;;
+        esac
+
+        # Handle lockfile updates
+        LOCKFILE_UPDATED="false"
+        if [[ "$UPDATE_LOCKFILE" == "true" ]]; then
+          MANIFEST_DIR=$(dirname "$MANIFEST_PATH")
+          MANIFEST_NAME=$(basename "$MANIFEST_PATH")
+
+          case "$MANIFEST_NAME" in
+            Cargo.toml)
+              if [[ -f "$MANIFEST_DIR/Cargo.lock" ]]; then
+                echo "::notice::Updating Cargo.lock..."
+                (cd "$MANIFEST_DIR" && cargo update --offline 2>/dev/null || cargo generate-lockfile 2>/dev/null || true)
+                if [[ -f "$MANIFEST_DIR/Cargo.lock" ]]; then
+                  LOCKFILE_UPDATED="true"
+                fi
+              fi
+              ;;
+            package.json)
+              if [[ -f "$MANIFEST_DIR/package-lock.json" ]]; then
+                echo "::notice::Updating package-lock.json..."
+                (cd "$MANIFEST_DIR" && npm install --package-lock-only 2>/dev/null || true)
+                LOCKFILE_UPDATED="true"
+              elif [[ -f "$MANIFEST_DIR/yarn.lock" ]]; then
+                echo "::notice::yarn.lock present but not auto-updated (run yarn install manually)"
+              fi
+              ;;
+            pyproject.toml)
+              if [[ -f "$MANIFEST_DIR/poetry.lock" ]]; then
+                echo "::notice::Updating poetry.lock..."
+                (cd "$MANIFEST_DIR" && poetry lock --no-update 2>/dev/null || true)
+                LOCKFILE_UPDATED="true"
+              fi
+              ;;
+          esac
+        fi
+
+        echo "::endgroup::"
+
+        # Set outputs
+        echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
+        echo "previous-version=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
+        echo "lockfile-updated=$LOCKFILE_UPDATED" >> "$GITHUB_OUTPUT"
+
+        echo "::notice::Updated $MANIFEST_PATH: $PREVIOUS_VERSION -> $NEW_VERSION"


### PR DESCRIPTION
## Summary

- Add 5 composite actions for attestation management in release pipelines
- Extract from `helm-charts` attestation-lib.sh patterns

## Actions Added

| Action | Description |
|--------|-------------|
| `attestation/extract-map` | Extract attestation map JSON from PR descriptions |
| `attestation/generate-digest` | Generate SHA256/SHA512 digests for attestation subjects |
| `attestation/update-pr-map` | Update PR description with attestation entries |
| `attestation/verify-chain` | Verify attestation chain using OCI bundles |
| `attestation/create` | Wrapper around `actions/attest-build-provenance` |

## Test plan

- [ ] Verify action.yml syntax is valid
- [ ] Test extract-map with sample PR body
- [ ] Test generate-digest with file and string inputs
- [ ] Test update-pr-map creates/updates attestation comments
- [ ] Test verify-chain with valid attestation bundle

Closes #23, #24, #25, #26, #36

🤖 Generated with [Claude Code](https://claude.ai/code)