### PR TITLE
feat(actions): add atomic-branch category actions

### DIFF
--- a/actions/atomic-branch/create-branch/README.md
+++ b/actions/atomic-branch/create-branch/README.md
@@ -1,0 +1,171 @@
+# atomic-branch/create-branch
+
+Create or update an artifact-specific branch for atomic release processing.
+
+For each changed artifact, this action creates a dedicated branch (e.g., `charts/my-chart`) containing only changes for that artifact. This enables per-artifact PRs and release tracking.
+
+## Usage
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/create-branch@v1
+  id: branch
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    branch-prefix: charts
+    target-branch: main
+
+- run: echo "Branch: ${{ steps.branch.outputs.branch }}"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `artifact` | Yes | - | Artifact name |
+| `artifact-path` | Yes | - | Path to artifacts directory |
+| `branch-prefix` | No | `<artifact-path>` | Prefix for branch name |
+| `target-branch` | No | `main` | Base branch for new branches |
+| `source-sha` | No | `github.sha` | Commit SHA to copy artifact from |
+| `source-pr` | No | - | Source PR number (for commit message) |
+| `sign-commits` | No | `false` | Sign commits with GPG |
+| `git-user-name` | No | `github-actions[bot]` | Git user name for commits |
+| `git-user-email` | No | `github-actions[bot]@users.noreply.github.com` | Git user email |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `branch` | Full branch name (e.g., "charts/my-chart") |
+| `updated` | "true" if branch was updated, "false" if no changes |
+| `sha` | New branch HEAD SHA |
+
+## Examples
+
+### Basic usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  - uses: arustydev/gha/actions/atomic-branch/create-branch@v1
+    id: branch
+    with:
+      artifact: my-chart
+      artifact-path: charts
+
+  - if: steps.branch.outputs.updated == 'true'
+    run: echo "Branch ${{ steps.branch.outputs.branch }} was updated"
+```
+
+### With source PR tracking
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/create-branch@v1
+  id: branch
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    target-branch: main
+    source-pr: ${{ github.event.pull_request.number }}
+```
+
+### Matrix strategy for multiple artifacts
+
+```yaml
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      artifacts: ${{ steps.detect.outputs.artifacts-json }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: arustydev/gha/actions/atomic-branch/detect-changes@v1
+        id: detect
+        with:
+          artifact-path: charts
+          manifest-file: Chart.yaml
+
+  create-branches:
+    needs: detect
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        artifact: ${{ fromJson(needs.detect.outputs.artifacts) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: arustydev/gha/actions/atomic-branch/create-branch@v1
+        id: branch
+        with:
+          artifact: ${{ matrix.artifact }}
+          artifact-path: charts
+          branch-prefix: charts
+```
+
+### With signed commits
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/create-branch@v1
+  with:
+    artifact: my-chart
+    artifact-path: charts
+    sign-commits: true
+    git-user-name: "Release Bot"
+    git-user-email: "release-bot@example.com"
+```
+
+## Prerequisites
+
+- Repository must be checked out with full history (`fetch-depth: 0`)
+- Token must have write access to create/push branches
+- Target branch must exist in the repository
+
+## How it works
+
+1. Determines the branch name from prefix and artifact name
+2. Checks if the branch already exists remotely
+3. If exists, compares tree hashes to detect actual changes
+4. Creates or updates the branch from the target branch
+5. Copies the artifact directory from the source commit
+6. Commits changes with optional source PR reference
+7. Pushes with retry logic and force-with-lease for safety
+
+## Retry Logic
+
+The action implements exponential backoff retry for push operations:
+
+1. First attempt: immediate push with `--force-with-lease`
+2. On failure: fetch, rebase, wait 2s, retry
+3. On second failure: fetch, rebase, wait 4s, retry
+4. Final fallback: force push without lease
+
+This handles concurrent updates gracefully while preferring safe push operations.
+
+## Branch Naming
+
+The branch name is constructed as:
+
+```
+<branch-prefix>/<artifact>
+```
+
+If `branch-prefix` is not provided, `artifact-path` is used:
+
+```
+<artifact-path>/<artifact>
+```
+
+Examples:
+- `charts/my-chart`
+- `crates/my-crate`
+- `packages/my-package`

--- a/actions/atomic-branch/create-branch/action.yml
+++ b/actions/atomic-branch/create-branch/action.yml
@@ -1,0 +1,228 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: "Create Artifact Branch"
+description: "Create or update an artifact-specific branch for atomic release processing"
+author: "aRustyDev"
+
+branding:
+  icon: "git-branch"
+  color: "green"
+
+inputs:
+  artifact:
+    description: "Artifact name"
+    required: true
+  artifact-path:
+    description: "Path to artifacts directory"
+    required: true
+  branch-prefix:
+    description: "Prefix for branch name (defaults to artifact-path)"
+    required: false
+    default: ""
+  target-branch:
+    description: "Base branch for new branches"
+    required: false
+    default: "main"
+  source-sha:
+    description: "Commit SHA to copy artifact from (defaults to GITHUB_SHA)"
+    required: false
+    default: ""
+  source-pr:
+    description: "Source PR number (for commit message)"
+    required: false
+    default: ""
+  sign-commits:
+    description: "Sign commits with GPG (requires GPG setup)"
+    required: false
+    default: "false"
+  git-user-name:
+    description: "Git user name for commits"
+    required: false
+    default: "github-actions[bot]"
+  git-user-email:
+    description: "Git user email for commits"
+    required: false
+    default: "github-actions[bot]@users.noreply.github.com"
+
+outputs:
+  branch:
+    description: "Full branch name"
+    value: ${{ steps.branch.outputs.branch }}
+  updated:
+    description: "Whether the branch was updated (true/false)"
+    value: ${{ steps.branch.outputs.updated }}
+  sha:
+    description: "New branch HEAD SHA"
+    value: ${{ steps.branch.outputs.sha }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure git
+      shell: bash
+      env:
+        GIT_USER_NAME: ${{ inputs.git-user-name }}
+        GIT_USER_EMAIL: ${{ inputs.git-user-email }}
+      run: |
+        git config user.name "$GIT_USER_NAME"
+        git config user.email "$GIT_USER_EMAIL"
+
+    - name: Create/update artifact branch
+      id: branch
+      shell: bash
+      env:
+        ARTIFACT: ${{ inputs.artifact }}
+        ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        SOURCE_SHA: ${{ inputs.source-sha }}
+        SOURCE_PR: ${{ inputs.source-pr }}
+        SIGN_COMMITS: ${{ inputs.sign-commits }}
+        GITHUB_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        # Use provided source SHA or fall back to GITHUB_SHA
+        if [[ -z "$SOURCE_SHA" ]]; then
+          SOURCE_SHA="$GITHUB_SHA"
+        fi
+
+        # Determine branch name
+        if [[ -n "$BRANCH_PREFIX" ]]; then
+          BRANCH="${BRANCH_PREFIX}/${ARTIFACT}"
+        else
+          BRANCH="${ARTIFACT_PATH}/${ARTIFACT}"
+        fi
+
+        echo "::group::Branch operations for $ARTIFACT"
+        echo "Branch: $BRANCH"
+        echo "Source SHA: $SOURCE_SHA"
+        echo "Target branch: $TARGET_BRANCH"
+
+        # Store current branch to return to later
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+        # Check if branch exists remotely
+        BRANCH_EXISTS=false
+        if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+          BRANCH_EXISTS=true
+          echo "::notice::Branch $BRANCH exists remotely, fetching..."
+          git fetch origin "$BRANCH"
+        fi
+
+        if [[ "$BRANCH_EXISTS" == "true" ]]; then
+          # Check if we need to update by comparing tree hashes
+          LOCAL_TREE=$(git rev-parse "${SOURCE_SHA}:${ARTIFACT_PATH}/${ARTIFACT}" 2>/dev/null || echo "none")
+          REMOTE_TREE=$(git rev-parse "origin/${BRANCH}:${ARTIFACT_PATH}/${ARTIFACT}" 2>/dev/null || echo "none")
+
+          if [[ "$LOCAL_TREE" == "$REMOTE_TREE" && "$LOCAL_TREE" != "none" ]]; then
+            echo "::notice::No changes to push for $ARTIFACT (tree hash identical)"
+            BRANCH_SHA=$(git rev-parse "origin/$BRANCH")
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            echo "sha=$BRANCH_SHA" >> "$GITHUB_OUTPUT"
+            echo "::endgroup::"
+            exit 0
+          fi
+
+          # Checkout the existing branch
+          git checkout -B "$BRANCH" "origin/$BRANCH"
+        else
+          echo "::notice::Creating new branch: $BRANCH from origin/$TARGET_BRANCH"
+          git checkout -b "$BRANCH" "origin/$TARGET_BRANCH"
+        fi
+
+        # Copy the artifact directory from the source commit
+        # First, remove existing artifact content if any
+        if [[ -d "${ARTIFACT_PATH}/${ARTIFACT}" ]]; then
+          git rm -rf "${ARTIFACT_PATH}/${ARTIFACT}" || true
+        fi
+
+        # Checkout artifact from source SHA
+        git checkout "$SOURCE_SHA" -- "${ARTIFACT_PATH}/${ARTIFACT}/"
+
+        # Check if there are changes to commit
+        if git diff --cached --quiet && git diff --quiet; then
+          echo "::notice::No changes to commit for $ARTIFACT"
+          BRANCH_SHA=$(git rev-parse HEAD)
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "updated=false" >> "$GITHUB_OUTPUT"
+          echo "sha=$BRANCH_SHA" >> "$GITHUB_OUTPUT"
+
+          # Return to original branch
+          git checkout "$CURRENT_BRANCH"
+          echo "::endgroup::"
+          exit 0
+        fi
+
+        # Stage changes
+        git add "${ARTIFACT_PATH}/${ARTIFACT}/"
+
+        # Build commit message
+        COMMIT_MSG="chore(${ARTIFACT}): sync from source"
+        if [[ -n "$SOURCE_PR" ]]; then
+          COMMIT_MSG="${COMMIT_MSG}"$'\n\n'"Source-PR: #${SOURCE_PR}"
+        fi
+        COMMIT_MSG="${COMMIT_MSG}"$'\n'"Source-SHA: ${SOURCE_SHA}"
+
+        # Commit (with optional signing)
+        if [[ "$SIGN_COMMITS" == "true" ]]; then
+          git commit -S -m "$COMMIT_MSG"
+        else
+          git commit -m "$COMMIT_MSG"
+        fi
+
+        # Push with retry logic
+        MAX_RETRIES=3
+        PUSH_SUCCESS=false
+
+        for ((i=1; i<=MAX_RETRIES; i++)); do
+          echo "::notice::Push attempt $i/$MAX_RETRIES..."
+
+          if git push origin "$BRANCH" --force-with-lease 2>&1; then
+            PUSH_SUCCESS=true
+            echo "::notice::Successfully pushed $BRANCH"
+            break
+          fi
+
+          if [[ $i -lt $MAX_RETRIES ]]; then
+            echo "::warning::Push failed, fetching and rebasing..."
+            git fetch origin "$BRANCH"
+
+            # Try to rebase
+            if git rebase "origin/$BRANCH" 2>&1; then
+              echo "::notice::Rebase successful, retrying push..."
+            else
+              echo "::warning::Rebase failed, aborting and force pushing..."
+              git rebase --abort 2>/dev/null || true
+              # On final retry, we might need to force push
+              if [[ $i -eq $((MAX_RETRIES - 1)) ]]; then
+                echo "::warning::Will attempt force push on next retry"
+              fi
+            fi
+
+            # Exponential backoff
+            sleep $((i * 2))
+          fi
+        done
+
+        if [[ "$PUSH_SUCCESS" != "true" ]]; then
+          # Final attempt with force push (without lease)
+          echo "::warning::Attempting force push as last resort..."
+          if git push origin "$BRANCH" --force 2>&1; then
+            PUSH_SUCCESS=true
+            echo "::notice::Force push successful for $BRANCH"
+          else
+            echo "::error::Failed to push $BRANCH after $MAX_RETRIES attempts"
+            git checkout "$CURRENT_BRANCH"
+            exit 1
+          fi
+        fi
+
+        BRANCH_SHA=$(git rev-parse HEAD)
+        echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+        echo "updated=true" >> "$GITHUB_OUTPUT"
+        echo "sha=$BRANCH_SHA" >> "$GITHUB_OUTPUT"
+
+        # Return to original branch
+        git checkout "$CURRENT_BRANCH"
+        echo "::endgroup::"

--- a/actions/atomic-branch/create-pr/README.md
+++ b/actions/atomic-branch/create-pr/README.md
@@ -1,0 +1,191 @@
+# atomic-branch/create-pr
+
+Create or update a PR with attestation lineage for atomic release processing.
+
+For each artifact branch, this action creates a PR to the target branch that carries forward the attestation chain from the source PR. This enables cryptographic verification of the complete release pipeline.
+
+## Usage
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/create-pr@v1
+  id: pr
+  with:
+    artifact: my-chart
+    branch: charts/my-chart
+    target-branch: main
+    source-pr: 123
+    attestation-map: '{"lint": "att-123", "test": "att-456"}'
+
+- run: echo "PR: ${{ steps.pr.outputs.pr-url }}"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `artifact` | Yes | - | Artifact name |
+| `branch` | Yes | - | Source branch for PR |
+| `target-branch` | No | `main` | Target branch for PR |
+| `source-pr` | No | - | Source PR number (for lineage) |
+| `attestation-map` | No | `{}` | JSON attestation map to carry forward |
+| `source-branch` | No | `integration` | Original source branch name |
+| `commit-sha` | No | `github.sha` | Source commit SHA for reference |
+| `labels` | No | - | Comma-separated list of labels |
+| `reviewers` | No | - | Comma-separated list of reviewers |
+| `team-reviewers` | No | - | Comma-separated list of team reviewers |
+| `draft` | No | `false` | Create PR as draft |
+| `token` | No | `github.token` | GitHub token for API operations |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `pr-number` | PR number (new or existing) |
+| `pr-action` | Action taken: `created`, `updated`, or `failed` |
+| `pr-url` | Full PR URL |
+
+## Examples
+
+### Basic usage
+
+```yaml
+steps:
+  - uses: arustydev/gha/actions/atomic-branch/create-pr@v1
+    id: pr
+    with:
+      artifact: my-chart
+      branch: charts/my-chart
+
+  - if: steps.pr.outputs.pr-action == 'created'
+    run: echo "Created new PR: ${{ steps.pr.outputs.pr-url }}"
+```
+
+### With attestation lineage
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/create-pr@v1
+  with:
+    artifact: my-chart
+    branch: charts/my-chart
+    target-branch: main
+    source-pr: ${{ needs.detect.outputs.source-pr }}
+    attestation-map: ${{ needs.detect.outputs.attestation-map }}
+    source-branch: integration
+    commit-sha: ${{ github.sha }}
+```
+
+### With labels and reviewers
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/create-pr@v1
+  with:
+    artifact: my-chart
+    branch: charts/my-chart
+    labels: "scope:chart, automation, release"
+    reviewers: "maintainer1, maintainer2"
+    team-reviewers: "my-org/release-team"
+```
+
+### Full atomic release pipeline
+
+```yaml
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      artifacts: ${{ steps.detect.outputs.artifacts-json }}
+      source-pr: ${{ steps.source.outputs.pr-number }}
+      attestation-map: ${{ steps.source.outputs.attestation-map }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: arustydev/gha/actions/atomic-branch/detect-changes@v1
+        id: detect
+        with:
+          artifact-path: charts
+          manifest-file: Chart.yaml
+      # ... find source PR and extract attestation map
+
+  create-prs:
+    needs: detect
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        artifact: ${{ fromJson(needs.detect.outputs.artifacts) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: arustydev/gha/actions/atomic-branch/create-branch@v1
+        id: branch
+        with:
+          artifact: ${{ matrix.artifact }}
+          artifact-path: charts
+
+      - uses: arustydev/gha/actions/atomic-branch/create-pr@v1
+        id: pr
+        with:
+          artifact: ${{ matrix.artifact }}
+          branch: ${{ steps.branch.outputs.branch }}
+          target-branch: main
+          source-pr: ${{ needs.detect.outputs.source-pr }}
+          attestation-map: ${{ needs.detect.outputs.attestation-map }}
+```
+
+## Attestation Map Format
+
+The attestation map is a JSON object that maps check names to attestation IDs:
+
+```json
+{
+  "lint-test-v1.32.11": "sha256:abc123...",
+  "install-test-v1.32.11": "sha256:def456...",
+  "security-scan": "sha256:789ghi..."
+}
+```
+
+This map is embedded in the PR body using HTML comments:
+
+```markdown
+<!-- ATTESTATION_MAP
+{"lint-test-v1.32.11": "sha256:abc123..."}
+-->
+```
+
+Downstream workflows can extract and verify these attestations to ensure the complete pipeline integrity.
+
+## PR Body Template
+
+The generated PR body includes:
+
+1. **Artifact name** - The artifact being promoted
+2. **Source information** - Source PR, branch, and commit SHA
+3. **Attestation lineage** - Expandable section showing attestation entries
+4. **Hidden attestation map** - Machine-readable attestation data in HTML comment
+
+## Race Condition Handling
+
+The action handles race conditions gracefully:
+
+1. First checks for existing PR before creating
+2. If PR creation fails due to existing PR (race), updates the existing one
+3. Returns appropriate `pr-action` output (`updated` vs `created`)
+
+## Token Permissions
+
+The token needs the following permissions:
+
+- `pull-requests: write` - To create/update PRs
+- `contents: read` - To read branch information
+
+For elevated operations (bypassing branch protection), use a GitHub App token:
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/create-pr@v1
+  with:
+    token: ${{ secrets.APP_TOKEN }}
+    # ... other inputs
+```

--- a/actions/atomic-branch/create-pr/action.yml
+++ b/actions/atomic-branch/create-pr/action.yml
@@ -1,0 +1,309 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: "Create Artifact PR"
+description: "Create or update a PR with attestation lineage for atomic release processing"
+author: "aRustyDev"
+
+branding:
+  icon: "git-pull-request"
+  color: "purple"
+
+inputs:
+  artifact:
+    description: "Artifact name"
+    required: true
+  branch:
+    description: "Source branch for PR"
+    required: true
+  target-branch:
+    description: "Target branch for PR"
+    required: false
+    default: "main"
+  source-pr:
+    description: "Source PR number (for lineage tracking)"
+    required: false
+    default: ""
+  attestation-map:
+    description: "JSON attestation map to carry forward"
+    required: false
+    default: "{}"
+  source-branch:
+    description: "Original source branch name (e.g., integration)"
+    required: false
+    default: "integration"
+  commit-sha:
+    description: "Source commit SHA for reference"
+    required: false
+    default: ""
+  labels:
+    description: "Comma-separated list of labels to add"
+    required: false
+    default: ""
+  reviewers:
+    description: "Comma-separated list of reviewers to request"
+    required: false
+    default: ""
+  team-reviewers:
+    description: "Comma-separated list of team reviewers to request"
+    required: false
+    default: ""
+  draft:
+    description: "Create PR as draft"
+    required: false
+    default: "false"
+  token:
+    description: "GitHub token for API operations"
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  pr-number:
+    description: "PR number (new or existing)"
+    value: ${{ steps.pr.outputs.pr_number }}
+  pr-action:
+    description: "Action taken: created, updated, or unchanged"
+    value: ${{ steps.pr.outputs.pr_action }}
+  pr-url:
+    description: "Full PR URL"
+    value: ${{ steps.pr.outputs.pr_url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create/update PR
+      id: pr
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        ARTIFACT: ${{ inputs.artifact }}
+        BRANCH: ${{ inputs.branch }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        SOURCE_PR: ${{ inputs.source-pr }}
+        ATTESTATION_MAP: ${{ inputs.attestation-map }}
+        COMMIT_SHA: ${{ inputs.commit-sha }}
+        SOURCE_BRANCH: ${{ inputs.source-branch }}
+        LABELS: ${{ inputs.labels }}
+        REVIEWERS: ${{ inputs.reviewers }}
+        TEAM_REVIEWERS: ${{ inputs.team-reviewers }}
+        DRAFT: ${{ inputs.draft }}
+        GITHUB_SHA: ${{ github.sha }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        # Use provided commit SHA or fall back to GITHUB_SHA
+        if [[ -z "$COMMIT_SHA" ]]; then
+          COMMIT_SHA="$GITHUB_SHA"
+        fi
+
+        echo "::group::PR operations for $ARTIFACT"
+        echo "Branch: $BRANCH"
+        echo "Target: $TARGET_BRANCH"
+        echo "Source PR: ${SOURCE_PR:-none}"
+
+        # Validate attestation map is valid JSON
+        if [[ -n "$ATTESTATION_MAP" && "$ATTESTATION_MAP" != "{}" ]]; then
+          if ! echo "$ATTESTATION_MAP" | jq -e . >/dev/null 2>&1; then
+            echo "::warning::Invalid attestation map JSON, using empty map"
+            ATTESTATION_MAP="{}"
+          fi
+        fi
+
+        # Check for existing PR
+        EXISTING_PR=$(gh pr list \
+          --head "$BRANCH" \
+          --base "$TARGET_BRANCH" \
+          --json number,url \
+          --jq '.[0] | "\(.number) \(.url)"' 2>/dev/null || echo "")
+
+        if [[ -n "$EXISTING_PR" ]]; then
+          EXISTING_PR_NUMBER=$(echo "$EXISTING_PR" | cut -d' ' -f1)
+          EXISTING_PR_URL=$(echo "$EXISTING_PR" | cut -d' ' -f2)
+          echo "::notice::Found existing PR #$EXISTING_PR_NUMBER"
+        fi
+
+        # Build PR body
+        build_pr_body() {
+          cat <<EOF
+        ## Artifact: $ARTIFACT
+
+        Promoting changes from \`$SOURCE_BRANCH\` branch to \`$TARGET_BRANCH\`.
+
+        ### Source
+        EOF
+
+          if [[ -n "$SOURCE_PR" ]]; then
+            echo "- **Source PR**: #$SOURCE_PR"
+          else
+            echo "- **Source PR**: _(not found)_"
+          fi
+
+          cat <<EOF
+        - **Source Branch**: \`$SOURCE_BRANCH\`
+        - **Source Commit**: \`$COMMIT_SHA\`
+
+        ### Attestation Lineage
+
+        This PR carries forward the attestation chain from the source PR.
+        EOF
+
+          # Show attestation entries if present
+          if [[ -n "$ATTESTATION_MAP" && "$ATTESTATION_MAP" != "{}" ]]; then
+            echo ""
+            echo "<details>"
+            echo "<summary>Attestation entries</summary>"
+            echo ""
+            echo "\`\`\`json"
+            echo "$ATTESTATION_MAP" | jq .
+            echo "\`\`\`"
+            echo "</details>"
+          fi
+
+          cat <<EOF
+
+        <!-- ATTESTATION_MAP
+        $ATTESTATION_MAP
+        -->
+
+        ---
+        *This PR was automatically created by the atomic-branch/create-pr action.*
+        EOF
+        }
+
+        PR_BODY=$(build_pr_body)
+        PR_TITLE="chore(${ARTIFACT}): promote to ${TARGET_BRANCH}"
+
+        if [[ -n "$EXISTING_PR_NUMBER" ]]; then
+          # Update existing PR
+          echo "::notice::Updating existing PR #$EXISTING_PR_NUMBER"
+
+          gh pr edit "$EXISTING_PR_NUMBER" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" 2>&1 || {
+            echo "::warning::Failed to update PR body, continuing..."
+          }
+
+          # Add labels if specified
+          if [[ -n "$LABELS" ]]; then
+            IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+            for label in "${LABEL_ARRAY[@]}"; do
+              label=$(echo "$label" | xargs)  # trim whitespace
+              if [[ -n "$label" ]]; then
+                gh pr edit "$EXISTING_PR_NUMBER" --add-label "$label" 2>/dev/null || true
+              fi
+            done
+          fi
+
+          echo "pr_number=$EXISTING_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_action=updated" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$EXISTING_PR_URL" >> "$GITHUB_OUTPUT"
+
+        else
+          # Create new PR
+          echo "::notice::Creating new PR for $ARTIFACT"
+
+          # Build create command
+          CREATE_ARGS=(
+            "--head" "$BRANCH"
+            "--base" "$TARGET_BRANCH"
+            "--title" "$PR_TITLE"
+            "--body" "$PR_BODY"
+          )
+
+          if [[ "$DRAFT" == "true" ]]; then
+            CREATE_ARGS+=("--draft")
+          fi
+
+          # Create PR and capture output
+          CREATE_OUTPUT=$(gh pr create "${CREATE_ARGS[@]}" 2>&1) || {
+            # Check if PR already exists (race condition)
+            RACE_PR=$(gh pr list \
+              --head "$BRANCH" \
+              --base "$TARGET_BRANCH" \
+              --json number,url \
+              --jq '.[0] | "\(.number) \(.url)"' 2>/dev/null || echo "")
+
+            if [[ -n "$RACE_PR" ]]; then
+              RACE_PR_NUMBER=$(echo "$RACE_PR" | cut -d' ' -f1)
+              RACE_PR_URL=$(echo "$RACE_PR" | cut -d' ' -f2)
+              echo "::notice::PR #$RACE_PR_NUMBER already exists (race condition)"
+
+              # Update the existing PR
+              gh pr edit "$RACE_PR_NUMBER" \
+                --title "$PR_TITLE" \
+                --body "$PR_BODY" 2>/dev/null || true
+
+              echo "pr_number=$RACE_PR_NUMBER" >> "$GITHUB_OUTPUT"
+              echo "pr_action=updated" >> "$GITHUB_OUTPUT"
+              echo "pr_url=$RACE_PR_URL" >> "$GITHUB_OUTPUT"
+              echo "::endgroup::"
+              exit 0
+            else
+              echo "::error::Failed to create PR: $CREATE_OUTPUT"
+              echo "pr_number=" >> "$GITHUB_OUTPUT"
+              echo "pr_action=failed" >> "$GITHUB_OUTPUT"
+              echo "pr_url=" >> "$GITHUB_OUTPUT"
+              echo "::endgroup::"
+              exit 1
+            fi
+          }
+
+          # Extract PR number and URL from output
+          if [[ "$CREATE_OUTPUT" =~ github.com/.*/pull/([0-9]+) ]]; then
+            NEW_PR_NUMBER="${BASH_REMATCH[1]}"
+            NEW_PR_URL="https://github.com/${GITHUB_REPOSITORY}/pull/${NEW_PR_NUMBER}"
+            echo "::notice::Created PR #$NEW_PR_NUMBER"
+          else
+            # Try to parse URL directly
+            NEW_PR_URL=$(echo "$CREATE_OUTPUT" | grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 || echo "")
+            if [[ -n "$NEW_PR_URL" ]]; then
+              NEW_PR_NUMBER=$(echo "$NEW_PR_URL" | grep -oE '[0-9]+$')
+              echo "::notice::Created PR #$NEW_PR_NUMBER"
+            else
+              echo "::error::Could not parse PR number from output: $CREATE_OUTPUT"
+              echo "pr_number=" >> "$GITHUB_OUTPUT"
+              echo "pr_action=failed" >> "$GITHUB_OUTPUT"
+              echo "pr_url=" >> "$GITHUB_OUTPUT"
+              echo "::endgroup::"
+              exit 1
+            fi
+          fi
+
+          # Add labels if specified
+          if [[ -n "$LABELS" ]]; then
+            IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+            for label in "${LABEL_ARRAY[@]}"; do
+              label=$(echo "$label" | xargs)
+              if [[ -n "$label" ]]; then
+                gh pr edit "$NEW_PR_NUMBER" --add-label "$label" 2>/dev/null || true
+              fi
+            done
+          fi
+
+          # Request reviewers if specified
+          if [[ -n "$REVIEWERS" ]]; then
+            IFS=',' read -ra REVIEWER_ARRAY <<< "$REVIEWERS"
+            for reviewer in "${REVIEWER_ARRAY[@]}"; do
+              reviewer=$(echo "$reviewer" | xargs)
+              if [[ -n "$reviewer" ]]; then
+                gh pr edit "$NEW_PR_NUMBER" --add-reviewer "$reviewer" 2>/dev/null || true
+              fi
+            done
+          fi
+
+          # Request team reviewers if specified
+          if [[ -n "$TEAM_REVIEWERS" ]]; then
+            IFS=',' read -ra TEAM_ARRAY <<< "$TEAM_REVIEWERS"
+            for team in "${TEAM_ARRAY[@]}"; do
+              team=$(echo "$team" | xargs)
+              if [[ -n "$team" ]]; then
+                gh pr edit "$NEW_PR_NUMBER" --add-reviewer "$team" 2>/dev/null || true
+              fi
+            done
+          fi
+
+          echo "pr_number=$NEW_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_action=created" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$NEW_PR_URL" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "::endgroup::"

--- a/actions/atomic-branch/detect-changes/README.md
+++ b/actions/atomic-branch/detect-changes/README.md
@@ -1,0 +1,143 @@
+# atomic-branch/detect-changes
+
+Detect changed artifacts in a commit range for atomic branch processing.
+
+This action compares the current branch against a target branch to identify which artifacts (charts, crates, packages) have changes that need processing. It categorizes changes as new, modified, or deleted.
+
+## Usage
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/detect-changes@v1
+  id: changes
+  with:
+    artifact-path: charts
+    manifest-file: Chart.yaml
+    target-branch: main
+
+- run: echo "Changed: ${{ steps.changes.outputs.artifacts }}"
+
+# Use in matrix strategy
+jobs:
+  process:
+    needs: detect
+    strategy:
+      matrix:
+        artifact: ${{ fromJson(needs.detect.outputs.artifacts-json) }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `artifact-path` | Yes | - | Path to artifacts directory (e.g., "charts", "crates") |
+| `manifest-file` | Yes | - | Manifest file within each artifact (e.g., "Chart.yaml", "Cargo.toml") |
+| `target-branch` | No | `main` | Branch to compare against |
+| `commit-range` | No | - | Explicit commit range (overrides target-branch comparison) |
+| `ignore-patterns` | No | - | Patterns to ignore (space-separated globs) |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `artifacts` | Space-separated list of all changed artifact names |
+| `artifacts-json` | JSON array of all changed artifacts (for matrix) |
+| `count` | Number of changed artifacts |
+| `new-artifacts` | Space-separated list of new artifact names |
+| `new-artifacts-json` | JSON array of new artifacts |
+| `modified-artifacts` | Space-separated list of modified artifact names |
+| `modified-artifacts-json` | JSON array of modified artifacts |
+| `deleted-artifacts` | Space-separated list of deleted artifact names |
+| `deleted-artifacts-json` | JSON array of deleted artifacts |
+
+## Examples
+
+### Basic usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+
+  - uses: arustydev/gha/actions/atomic-branch/detect-changes@v1
+    id: changes
+    with:
+      artifact-path: charts
+      manifest-file: Chart.yaml
+      target-branch: main
+
+  - if: steps.changes.outputs.count != '0'
+    run: |
+      echo "Changed charts: ${{ steps.changes.outputs.artifacts }}"
+      echo "New charts: ${{ steps.changes.outputs.new-artifacts }}"
+      echo "Modified charts: ${{ steps.changes.outputs.modified-artifacts }}"
+```
+
+### Using explicit commit range
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/detect-changes@v1
+  id: changes
+  with:
+    artifact-path: crates
+    manifest-file: Cargo.toml
+    commit-range: "HEAD~5..HEAD"
+```
+
+### With ignore patterns
+
+```yaml
+- uses: arustydev/gha/actions/atomic-branch/detect-changes@v1
+  id: changes
+  with:
+    artifact-path: charts
+    manifest-file: Chart.yaml
+    ignore-patterns: "test-* deprecated-*"
+```
+
+### Matrix strategy for processing
+
+```yaml
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      artifacts: ${{ steps.changes.outputs.artifacts-json }}
+      count: ${{ steps.changes.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: arustydev/gha/actions/atomic-branch/detect-changes@v1
+        id: changes
+        with:
+          artifact-path: charts
+          manifest-file: Chart.yaml
+
+  process:
+    needs: detect
+    if: needs.detect.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        artifact: ${{ fromJson(needs.detect.outputs.artifacts) }}
+      fail-fast: false
+    steps:
+      - run: echo "Processing ${{ matrix.artifact }}"
+```
+
+## Prerequisites
+
+- Repository must be checked out with full history (`fetch-depth: 0`)
+- Target branch must exist in the repository
+- `jq` must be available (included in GitHub-hosted runners)
+
+## How it works
+
+1. Determines the commit range based on `target-branch` or explicit `commit-range`
+2. Uses `git diff --name-only` to get changed files
+3. Filters files to the specified `artifact-path`
+4. Extracts unique artifact directory names
+5. Validates each artifact has the required `manifest-file`
+6. Categorizes artifacts as new, modified, or deleted
+7. Outputs results in both space-separated and JSON formats

--- a/actions/atomic-branch/detect-changes/action.yml
+++ b/actions/atomic-branch/detect-changes/action.yml
@@ -1,0 +1,225 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: "Detect Changed Artifacts"
+description: "Detect changed artifacts in a commit range for atomic branch processing"
+author: "aRustyDev"
+
+branding:
+  icon: "git-branch"
+  color: "blue"
+
+inputs:
+  artifact-path:
+    description: 'Path to artifacts directory (e.g., "charts", "crates")'
+    required: true
+  manifest-file:
+    description: 'Manifest file within each artifact (e.g., "Chart.yaml", "Cargo.toml")'
+    required: true
+  target-branch:
+    description: "Branch to compare against"
+    required: false
+    default: "main"
+  commit-range:
+    description: "Explicit commit range (overrides target-branch comparison)"
+    required: false
+    default: ""
+  ignore-patterns:
+    description: "Patterns to ignore (space-separated globs)"
+    required: false
+    default: ""
+
+outputs:
+  artifacts:
+    description: "Space-separated list of changed artifact names"
+    value: ${{ steps.detect.outputs.artifacts }}
+  artifacts-json:
+    description: "JSON array of changed artifacts (for matrix)"
+    value: ${{ steps.detect.outputs.artifacts_json }}
+  count:
+    description: "Number of changed artifacts"
+    value: ${{ steps.detect.outputs.count }}
+  new-artifacts:
+    description: "Space-separated list of new artifact names"
+    value: ${{ steps.detect.outputs.new_artifacts }}
+  new-artifacts-json:
+    description: "JSON array of new artifacts"
+    value: ${{ steps.detect.outputs.new_artifacts_json }}
+  modified-artifacts:
+    description: "Space-separated list of modified artifact names"
+    value: ${{ steps.detect.outputs.modified_artifacts }}
+  modified-artifacts-json:
+    description: "JSON array of modified artifacts"
+    value: ${{ steps.detect.outputs.modified_artifacts_json }}
+  deleted-artifacts:
+    description: "Space-separated list of deleted artifact names"
+    value: ${{ steps.detect.outputs.deleted_artifacts }}
+  deleted-artifacts-json:
+    description: "JSON array of deleted artifacts"
+    value: ${{ steps.detect.outputs.deleted_artifacts_json }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Detect changed artifacts
+      id: detect
+      shell: bash
+      env:
+        ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        MANIFEST_FILE: ${{ inputs.manifest-file }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        COMMIT_RANGE: ${{ inputs.commit-range }}
+        IGNORE_PATTERNS: ${{ inputs.ignore-patterns }}
+      run: |
+        set -euo pipefail
+
+        # Determine commit range
+        if [[ -n "$COMMIT_RANGE" ]]; then
+          RANGE="$COMMIT_RANGE"
+          echo "::notice::Using explicit commit range: $RANGE"
+        else
+          RANGE="origin/${TARGET_BRANCH}..HEAD"
+          echo "::notice::Comparing against target branch: $RANGE"
+        fi
+
+        # Validate that the range is valid
+        if ! git rev-parse "${RANGE%%..*}" >/dev/null 2>&1; then
+          echo "::error::Invalid commit range: $RANGE"
+          exit 1
+        fi
+
+        # Get all changed files
+        CHANGED_FILES=$(git diff --name-only "$RANGE" 2>/dev/null || true)
+
+        if [[ -z "$CHANGED_FILES" ]]; then
+          echo "::notice::No changed files detected in range: $RANGE"
+          echo "artifacts=" >> "$GITHUB_OUTPUT"
+          echo "artifacts_json=[]" >> "$GITHUB_OUTPUT"
+          echo "count=0" >> "$GITHUB_OUTPUT"
+          echo "new_artifacts=" >> "$GITHUB_OUTPUT"
+          echo "new_artifacts_json=[]" >> "$GITHUB_OUTPUT"
+          echo "modified_artifacts=" >> "$GITHUB_OUTPUT"
+          echo "modified_artifacts_json=[]" >> "$GITHUB_OUTPUT"
+          echo "deleted_artifacts=" >> "$GITHUB_OUTPUT"
+          echo "deleted_artifacts_json=[]" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Filter to artifact path and extract unique artifact names
+        ARTIFACT_DIRS=$(echo "$CHANGED_FILES" | grep "^${ARTIFACT_PATH}/" | cut -d'/' -f2 | sort -u || true)
+
+        if [[ -z "$ARTIFACT_DIRS" ]]; then
+          echo "::notice::No artifact changes detected in ${ARTIFACT_PATH}/"
+          echo "artifacts=" >> "$GITHUB_OUTPUT"
+          echo "artifacts_json=[]" >> "$GITHUB_OUTPUT"
+          echo "count=0" >> "$GITHUB_OUTPUT"
+          echo "new_artifacts=" >> "$GITHUB_OUTPUT"
+          echo "new_artifacts_json=[]" >> "$GITHUB_OUTPUT"
+          echo "modified_artifacts=" >> "$GITHUB_OUTPUT"
+          echo "modified_artifacts_json=[]" >> "$GITHUB_OUTPUT"
+          echo "deleted_artifacts=" >> "$GITHUB_OUTPUT"
+          echo "deleted_artifacts_json=[]" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Initialize arrays
+        ALL_ARTIFACTS=""
+        NEW_ARTIFACTS=""
+        MODIFIED_ARTIFACTS=""
+        DELETED_ARTIFACTS=""
+
+        # Process each potential artifact
+        for dir in $ARTIFACT_DIRS; do
+          # Apply ignore patterns
+          SKIP=false
+          if [[ -n "$IGNORE_PATTERNS" ]]; then
+            for pattern in $IGNORE_PATTERNS; do
+              # shellcheck disable=SC2053
+              if [[ "$dir" == $pattern ]]; then
+                echo "::notice::Skipping $dir - matches ignore pattern: $pattern"
+                SKIP=true
+                break
+              fi
+            done
+          fi
+
+          if [[ "$SKIP" == "true" ]]; then
+            continue
+          fi
+
+          # Check artifact status
+          MANIFEST_PATH="${ARTIFACT_PATH}/${dir}/${MANIFEST_FILE}"
+
+          # Check if manifest exists in current HEAD
+          if git show "HEAD:${MANIFEST_PATH}" >/dev/null 2>&1; then
+            # Manifest exists now - check if it existed before
+            if git show "${RANGE%%..*}:${MANIFEST_PATH}" >/dev/null 2>&1; then
+              # Existed before -> Modified
+              MODIFIED_ARTIFACTS="$MODIFIED_ARTIFACTS $dir"
+              echo "::notice::Modified artifact: $dir"
+            else
+              # Did not exist before -> New
+              NEW_ARTIFACTS="$NEW_ARTIFACTS $dir"
+              echo "::notice::New artifact: $dir"
+            fi
+            ALL_ARTIFACTS="$ALL_ARTIFACTS $dir"
+          else
+            # Manifest does not exist now - check if it existed before
+            if git show "${RANGE%%..*}:${MANIFEST_PATH}" >/dev/null 2>&1; then
+              # Existed before but not now -> Deleted
+              DELETED_ARTIFACTS="$DELETED_ARTIFACTS $dir"
+              echo "::notice::Deleted artifact: $dir"
+            else
+              echo "::notice::Skipping $dir - no $MANIFEST_FILE found (not a valid artifact)"
+            fi
+          fi
+        done
+
+        # Trim whitespace
+        ALL_ARTIFACTS=$(echo "$ALL_ARTIFACTS" | xargs)
+        NEW_ARTIFACTS=$(echo "$NEW_ARTIFACTS" | xargs)
+        MODIFIED_ARTIFACTS=$(echo "$MODIFIED_ARTIFACTS" | xargs)
+        DELETED_ARTIFACTS=$(echo "$DELETED_ARTIFACTS" | xargs)
+
+        # Count artifacts
+        if [[ -n "$ALL_ARTIFACTS" ]]; then
+          COUNT=$(echo "$ALL_ARTIFACTS" | wc -w | xargs)
+        else
+          COUNT=0
+        fi
+
+        # Convert to JSON arrays
+        to_json_array() {
+          local input="$1"
+          if [[ -z "$input" ]]; then
+            echo "[]"
+          else
+            echo "$input" | tr ' ' '\n' | jq -R -s -c 'split("\n") | map(select(length > 0))'
+          fi
+        }
+
+        ALL_ARTIFACTS_JSON=$(to_json_array "$ALL_ARTIFACTS")
+        NEW_ARTIFACTS_JSON=$(to_json_array "$NEW_ARTIFACTS")
+        MODIFIED_ARTIFACTS_JSON=$(to_json_array "$MODIFIED_ARTIFACTS")
+        DELETED_ARTIFACTS_JSON=$(to_json_array "$DELETED_ARTIFACTS")
+
+        # Set outputs
+        echo "artifacts=$ALL_ARTIFACTS" >> "$GITHUB_OUTPUT"
+        echo "artifacts_json=$ALL_ARTIFACTS_JSON" >> "$GITHUB_OUTPUT"
+        echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+        echo "new_artifacts=$NEW_ARTIFACTS" >> "$GITHUB_OUTPUT"
+        echo "new_artifacts_json=$NEW_ARTIFACTS_JSON" >> "$GITHUB_OUTPUT"
+        echo "modified_artifacts=$MODIFIED_ARTIFACTS" >> "$GITHUB_OUTPUT"
+        echo "modified_artifacts_json=$MODIFIED_ARTIFACTS_JSON" >> "$GITHUB_OUTPUT"
+        echo "deleted_artifacts=$DELETED_ARTIFACTS" >> "$GITHUB_OUTPUT"
+        echo "deleted_artifacts_json=$DELETED_ARTIFACTS_JSON" >> "$GITHUB_OUTPUT"
+
+        # Summary
+        echo "::notice::Changed artifacts ($COUNT): $ALL_ARTIFACTS"
+        if [[ -n "$NEW_ARTIFACTS" ]]; then
+          echo "::notice::New: $NEW_ARTIFACTS"
+        fi
+        if [[ -n "$MODIFIED_ARTIFACTS" ]]; then
+          echo "::notice::Modified: $MODIFIED_ARTIFACTS"
+        fi
+        if [[ -n "$DELETED_ARTIFACTS" ]]; then
+          echo "::notice::Deleted: $DELETED_ARTIFACTS"
+        fi


### PR DESCRIPTION
## Summary

- Add 3 composite actions for atomic branch processing in release pipelines
- Enable per-artifact branching with attestation lineage tracking

## Actions Added

| Action | Description |
|--------|-------------|
| `atomic-branch/detect-changes` | Detect new/modified/deleted artifacts in commit range |
| `atomic-branch/create-branch` | Create artifact-specific branches with retry logic |
| `atomic-branch/create-pr` | Create PRs with attestation lineage from source PRs |

## Test plan

- [ ] Verify action.yml syntax is valid
- [ ] Test detect-changes with modified chart directory
- [ ] Test create-branch creates proper branch naming
- [ ] Test create-pr carries forward attestation map

Closes #27, #28, #29

🤖 Generated with [Claude Code](https://claude.ai/code)